### PR TITLE
Tradução: data-visualize.qmd

### DIFF
--- a/data-visualize.qmd
+++ b/data-visualize.qmd
@@ -158,7 +158,7 @@ ggplot(pinguins, aes(x = comprimento_nadadeira, y = massa_corporal)) +
 Vamos recriar esse gráfico passo a passo.
 
 No ggplot2, você inicia um gráfico com a função `ggplot()`, definindo um objeto de gráfico ao qual você adiciona **camadas**.
-O primeiro argumento de `ggplot()` é o conjunto de dados a ser usado no gráfico e, portanto, `ggplot(data = pinguins)` cria um gráfico vazio que está preparado para exibir os dados dos `pinguins`, mas, como ainda não dissemos como visualizá-los, por enquanto ele está vazio.
+O primeiro argumento de `ggplot()` é o conjunto de dados a ser usado no gráfico e, portanto, `ggplot(data = pinguins)` cria um gráfico vazio que está preparado para exibir os dados dos `pinguins`, mas, como ainda não dissemos como fazer a visualização, por enquanto ele está vazio.
 Esse não é um gráfico muito interessante, mas você pode pensar nele como uma tela vazia na qual você pintará as camadas restantes do seu gráfico.
 
 ```{r}

--- a/data-visualize.qmd
+++ b/data-visualize.qmd
@@ -368,7 +368,7 @@ Finalmente temos um gráfico que corresponde perfeitamente ao nosso "objetivo fi
     E quantas colunas?
 
 2.  O que a variável `profundidade_bico` no *data frame* `pinguins` descreve?
-    Leia a ajuda do `?pinguins` para descobrir.
+    Leia a documentação da base pinguins para descobrir, utilizando o comando `?pinguins` .
 
 3.  Faça um gráfico de dispersão de `profundidade_bico` em função de `comprimento_bico`.
     Ou seja, faça um gráfico de dispersão com `profundidade_bico` no eixo y e `comprimento_bico` no eixo x.

--- a/data-visualize.qmd
+++ b/data-visualize.qmd
@@ -675,7 +675,7 @@ Também personalizamos a espessura das linhas usando o argumento `linewidth` par
 
 Além disso, podemos mapear `especie` para os atributos estéticos `color` e `fill` e usar o atributo `alpha` para adicionar transparência às curvas de densidade preenchidas.
 Esse atributo assume valores entre 0 (completamente transparente) e 1 (completamente opaco).
-No gráfico a seguir, ela está *definida* como 0,5.
+No gráfico a seguir, ela está *definida* como 0.5.
 
 ```{r}
 #| warning: false

--- a/data-visualize.qmd
+++ b/data-visualize.qmd
@@ -47,7 +47,7 @@ library(tidyverse)
 
 Você só precisa instalar um pacote uma vez, mas precisa carregá-lo sempre que iniciar uma nova sessão.
 
-Além do tidyverse, nós também usaremos o pacote **dados**, que inclui um banco de dados com medidas corporais de pinguins de três ilhas do Arquipélago Palmer, junto do pacote ggthemes, que fornece uma paleta de cores segura para pessoas com daltonismo.
+Além do tidyverse, nós também usaremos o pacote **dados**, que inclui várias bases de dados, incluindo um com medidas corporais de pinguins de três ilhas do Arquipélago Palmer, junto do pacote ggthemes, que fornece uma paleta de cores segura para pessoas com daltonismo.
 
 ```{r}
 library(dados)
@@ -158,7 +158,7 @@ ggplot(pinguins, aes(x = comprimento_nadadeira, y = massa_corporal)) +
 Vamos recriar esse gráfico passo a passo.
 
 No ggplot2, você inicia um gráfico com a função `ggplot()`, definindo um objeto de gráfico ao qual você adiciona **camadas**.
-O primeiro argumento de `ggplot()` é o conjunto de dados a ser usado no gráfico e, portanto, `ggplot(data = pinguins)` cria um gráfico vazio que está preparado para exibir os dados dos `pinguins`, mas, como ainda não dissemos como fazer a visualização, por enquanto ele está vazio.
+O primeiro argumento da função `ggplot()` é o conjunto de dados a ser usado no gráfico e, portanto, `ggplot(data = pinguins)` cria um gráfico vazio que está preparado para exibir os dados dos `pinguins`, mas, como ainda não dissemos como fazer a visualização, por enquanto ele está vazio.
 Esse não é um gráfico muito interessante, mas você pode pensar nele como uma tela vazia na qual você pintará as camadas restantes do seu gráfico.
 
 ```{r}
@@ -192,7 +192,7 @@ Nossa tela vazia agora está mais estruturada: está claro onde os comprimentos 
 Mas os pinguins em si ainda não estão no gráfico.
 Isso ocorre porque ainda não definimos, em nosso código, como representar as observações de nosso *data frame* em nosso gráfico.
 
-Para isso, precisamos definir uma **geom**: a geometria que um gráfico usa para representar os dados.
+Para isso, precisamos definir um **geom**: A geometria que um gráfico usa para representar os dados.
 Essas geometrias são disponibilizados no ggplot2 com funções que começam com `geom_`.
 As pessoas geralmente descrevem os gráficos pelo tipo de geom que o gráfico usa.
 Por exemplo, os gráficos de barras usam geometrias de barras (`geom_bar()`), os gráficos de linhas usam geometrias de linhas (`geom_line()`), os boxplots usam geometrias de boxplot (`geom_boxplot()`), os gráficos de dispersão usam geometrias de pontos (`geom_point()`) e assim por diante.
@@ -222,14 +222,14 @@ Antes de adicionarmos mais camadas a esse gráfico, vamos parar por um momento e
 
 > Removed 2 rows containing missing values (`geom_point()`).
 
-Estamos vendo essa mensagem porque há dois pinguins em nosso conjunto de dados com valores faltantes (*missing values - *NA*) de massa corporal e/ou comprimento da nadadeira e o ggplot2 não tem como representá-los no gráfico sem esses dois valores.
+Estamos vendo essa mensagem porque há dois pinguins em nosso conjunto de dados com valores faltantes (*missing values -* NA\*) de massa corporal e/ou comprimento da nadadeira e o ggplot2 não tem como representá-los no gráfico sem esses dois valores.
 Assim como o R, o ggplot2 adota a filosofia de que os valores faltantes nunca devem desaparecer silenciosamente.
 Esse tipo de aviso é provavelmente um dos tipos mais comuns de avisos que você verá ao trabalhar com dados reais - os valores faltantes são um problema muito comum e você aprenderá mais sobre eles ao longo do livro, especialmente em @sec-missing-values.
 Nos demais gráficos deste capítulo, vamos suprimir esse aviso para que ele não seja mostrado em cada gráfico que fizermos.
 
 ### Adicionando atributos estéticos e camadas {#sec-adding-aesthetics-layers}
 
-Gráficos de dispersão são úteis para exibir a relação entre duas variáveis numéricas, mas é sempre uma boa ideia ser cético em relação a qualquer relação aparente entre duas variáveis e perguntar se pode haver outras variáveis que expliquem ou mudem a natureza dessa relação aparente.
+Gráficos de dispersão são úteis para exibir a relação entre duas variáveis numéricas, mas é sempre uma boa ideia ter uma postura cética em relação a qualquer relação aparente entre duas variáveis e perguntar se pode haver outras variáveis que expliquem ou mudem a natureza dessa relação aparente.
 Por exemplo, a relação entre o comprimento das nadadeira e a massa corporal difere de acordo com a espécie?
 Vamos incluir as espécies em nosso gráfico e ver se isso revela alguma ideia adicional sobre a relação aparente entre essas variáveis.
 Faremos isso representando as espécies com pontos de cores diferentes.
@@ -466,7 +466,7 @@ ggplot(
   geom_point()
 ```
 
-Normalmente, o primeiro ou os dois primeiros argumentos de uma função são tão importantes que você deve saber usar de cor.
+Normalmente, o primeiro ou os dois primeiros argumentos de uma função são tão importantes que você logo saberá usar eles de cor.
 Os dois primeiros argumentos de `ggplot()` são `data` e `mapping`; no restante do livro, não escreveremos esses nomes.
 Isso economiza digitação e, ao reduzir a quantidade de texto extra, facilita a visualização das diferenças entre os gráficos.
 Essa é uma preocupação de programação realmente importante, à qual voltaremos em @sec-functions.
@@ -762,7 +762,7 @@ ggplot(pinguins, aes(x = comprimento_nadadeira, y = massa_corporal)) +
 ```
 
 No entanto, mapear muitos atributos estéticos a um gráfico faz com que ele fique desordenado e difícil de entender.
-Outra maneira, que é particularmente útil para variáveis categóricas, é dividir seu gráfico em **facetas**, subdivisões ou janelas que exibem um subconjunto dos dados cada uma.
+Outra maneira, que é particularmente útil para variáveis categóricas, é dividir seu gráfico em **facetas** (*facets*), subdivisões ou janelas que exibem um subconjunto dos dados cada uma.
 
 Para separar seu gráfico em facetas por uma única variável, use `facet_wrap()`.
 O primeiro argumento de `facet_wrap()` é uma fórmula[^data-visualize-3], que você cria com `~` seguido do nome de uma variável.
@@ -861,7 +861,7 @@ Se você não especificar a largura `width` e a altura `height`, elas serão tir
 Para obter um código reprodutível, você deverá especificá-los.
 Você pode obter mais informações sobre a função `ggsave()` na documentação.
 
-De modo geral, entretanto, recomendamos que você monte seus relatórios finais usando o Quarto, um sistema de autoria reproduzível que permite intercalar seu código e sua escrita e incluir automaticamente seus gráficos em seus relatórios.
+De modo geral, entretanto, recomendamos que você monte seus relatórios finais usando o Quarto, um sistema de escrita reprodutível que permite intercalar seu código e sua escrita e incluir automaticamente seus gráficos em seus relatórios.
 Você aprenderá mais sobre o Quarto em @sec-quarto.
 
 ### Exercícios
@@ -917,9 +917,9 @@ Outra ferramenta excelente é o Google: tente pesquisar a mensagem de erro no Go
 Neste capítulo, você aprendeu os fundamentos da visualização de dados com o ggplot2.
 Começamos com a ideia básica que sustenta o ggplot2: uma visualização é um mapeamento de variáveis em seus dados para atributos estéticos como posição (*position*), cor (*color*), tamanho (*size*) e forma (*shape*).
 Em seguida, você aprendeu a aumentar a complexidade e melhorar a apresentação de seus gráficos camada por camada.
-Você também aprendeu sobre gráficos comumente usados para visualizar a distribuição de uma única variável, bem como para visualizar relações entre duas ou mais variáveis ao utilizar mapeamentos de atributos estéticos adicionais e/ou dividindo seu gráfico em pequenos múltiplos usando facetas.
+Você também aprendeu sobre gráficos comumente usados para visualizar a distribuição de uma única variável, bem como para visualizar relações entre duas ou mais variáveis ao utilizar mapeamentos de atributos estéticos adicionais e/ou dividindo seu gráfico em pequenos gráficos usando facetas.
 
 Usaremos as visualizações repetidamente ao longo deste livro, introduzindo novas técnicas à medida que precisarmos delas, além de nos aprofundarmos na criação de visualizações com o ggplot2 em @sec-layers por meio da @sec-communication.
 
 Com as noções básicas de visualização em seu currículo, no próximo capítulo mudaremos um pouco a direção e daremos algumas orientações práticas sobre o fluxo de trabalho.
-Intercalamos conselhos sobre fluxo de trabalho com ferramentas de ciência de dados ao longo desta parte do livro, pois isso o ajudará a se manter organizado à medida que você escreve quantidades cada vez maiores de código em R.
+Intercalamos conselhos sobre fluxo de trabalho com ferramentas de ciência de dados ao longo desta parte do livro, pois isso te ajudará a manter a organização à medida que você escreve quantidades cada vez maiores de código em R.

--- a/data-visualize.qmd
+++ b/data-visualize.qmd
@@ -644,7 +644,7 @@ Conforme mostrado em @fig-eda-boxplot, cada boxplot consiste em:
 #| label: fig-eda-boxplot
 #| echo: false
 #| fig-cap: |
-#|   Diagrama sobre como um boxplot é criado.
+#|   Diagrama mostrando como um boxplot é criado.
 #| fig-alt: |
 #|   Um diagrama exibindo como um boxplot é criado seguindo os passos acima.
 

--- a/data-visualize.qmd
+++ b/data-visualize.qmd
@@ -223,7 +223,7 @@ Antes de adicionarmos mais camadas a esse gráfico, vamos parar por um momento e
 > Removed 2 rows containing missing values (`geom_point()`).
 
 Estamos vendo essa mensagem porque há dois pinguins em nosso conjunto de dados com valores faltantes (*missing values - *NA*) de massa corporal e/ou comprimento da nadadeira e o ggplot2 não tem como representá-los no gráfico sem esses dois valores.
-Assim como o R, o ggplot2 adota a filosofia de que os valores ausentes nunca devem desaparecer silenciosamente.
+Assim como o R, o ggplot2 adota a filosofia de que os valores faltantes nunca devem desaparecer silenciosamente.
 Esse tipo de aviso é provavelmente um dos tipos mais comuns de avisos que você verá ao trabalhar com dados reais - os valores ausentes são um problema muito comum e você aprenderá mais sobre eles ao longo do livro, especialmente em @sec-missing-values.
 Nos demais gráficos deste capítulo, suprimiuprimir esse aviso para que ele não seja mostrado em cada gráfico que fizermos.
 

--- a/data-visualize.qmd
+++ b/data-visualize.qmd
@@ -628,7 +628,7 @@ Conforme mostrado em @fig-eda-boxplot, cada boxplot consiste em:
 -   Pontos que apresentam observações com valores maiores que 1,5 vezes o IIQ de qualquer borda da caixa.
     Esses pontos discrepantes são incomuns e, por isso, são plotados individualmente.
 
--   Uma linha que se estende de cada extremidade da caixa e vai até o ponto mais distante sem *outlier* na distribuição.
+-   Uma linha que se estende de cada extremidade da caixa e vai até o ponto mais distante (sem considerar os valores discrepantes - *outliers*) na distribuição.
 
 ```{r}
 #| label: fig-eda-boxplot

--- a/data-visualize.qmd
+++ b/data-visualize.qmd
@@ -316,7 +316,7 @@ Portanto, além da cor, também podemos mapear `especie` para a estética `shape
 ```{r}
 #| warning: false
 #| fig-alt: |
-#|   Um gráfico de dispersão da massa corporal em função o comprimento da
+#|   Um gráfico de dispersão da massa corporal em função do comprimento da
 #|   nadadeira dos pinguins. Sobreposta ao gráfico de dispersão está
 #|   uma única linha de melhor ajuste que mostra a relação entre essas 
 #|   variáveis para cada espécie (Pinguim-de-adélia, Pinguim-de-barbicha 

--- a/data-visualize.qmd
+++ b/data-visualize.qmd
@@ -550,7 +550,7 @@ Você pode definir a largura dos intervalos em um histograma com o argumento *bi
 Você deve sempre explorar uma variedade de larguras de intervalos ao trabalhar com histogramas, pois diferentes larguras de intervalos podem revelar padrões diferentes.
 Nos gráficos abaixo, uma largura de intervalo de 20 é muito estreita, resultando em muitas barras, o que dificulta a determinação da forma da distribuição.
 Da mesma forma, uma largura de intervalo de 2000 é muito alta, resultando em todos os dados sendo agrupados em apenas três barras, o que também dificulta a determinação da forma da distribuição.
-Uma largura de intervalo de 200 proporciona um balanço adequado.
+Uma largura de intervalo de 200 proporciona um balanço mais adequado.
 
 ```{r}
 #| warning: false

--- a/data-visualize.qmd
+++ b/data-visualize.qmd
@@ -225,7 +225,7 @@ Antes de adicionarmos mais camadas a esse gráfico, vamos parar por um momento e
 Estamos vendo essa mensagem porque há dois pinguins em nosso conjunto de dados com valores faltantes (*missing values - *NA*) de massa corporal e/ou comprimento da nadadeira e o ggplot2 não tem como representá-los no gráfico sem esses dois valores.
 Assim como o R, o ggplot2 adota a filosofia de que os valores faltantes nunca devem desaparecer silenciosamente.
 Esse tipo de aviso é provavelmente um dos tipos mais comuns de avisos que você verá ao trabalhar com dados reais - os valores faltantes são um problema muito comum e você aprenderá mais sobre eles ao longo do livro, especialmente em @sec-missing-values.
-Nos demais gráficos deste capítulo, suprimiuprimir esse aviso para que ele não seja mostrado em cada gráfico que fizermos.
+Nos demais gráficos deste capítulo, vamos suprimir esse aviso para que ele não seja mostrado em cada gráfico que fizermos.
 
 ### Adicionando atributos estéticos e camadas {#sec-adding-aesthetics-layers}
 

--- a/data-visualize.qmd
+++ b/data-visualize.qmd
@@ -480,7 +480,7 @@ ggplot(pinguins, aes(x = comprimento_nadadeira, y = massa_corporal)) +
   geom_point()
 ```
 
-No futuro, você também aprenderá sobre o pipe, `|>`, que permitirá que você crie esse gráfico com:
+No futuro, você também aprenderá sobre o *pipe* (encadeamento), `|>`, que permitirá que você crie esse gráfico com a seguinte sintaxe:
 
 ```{r}
 #| eval: false

--- a/data-visualize.qmd
+++ b/data-visualize.qmd
@@ -170,7 +170,7 @@ ggplot(data = pinguins)
 
 Em seguida, precisamos informar ao `ggplot()` como as informações dos nossos dados serão representadas visualmente.
 O argumento `mapping` (mapeamento) da função `ggplot()` define como as variáveis em seu conjunto de dados são mapeadas para as propriedades visuais (**estética**) do gráfico.
-O argumento `mapping` é sempre definido na função `aes()`, e os argumentos `x` e `y` de `aes()` especificam quais variáveis devem ser mapeadas para os eixos x e y.
+O argumento `mapping` é sempre definido na função `aes()`, e os argumentos `x` e `y` de `aes()` especificam quais variáveis devem ser mapeadas nos eixos x e y.
 Por enquanto, mapearemos apenas o comprimento da nadadeira para o atributo estético `x` e a massa corporal para o atributo `y`.
 O ggplot2 procura as variáveis mapeadas no argumento `data`, nesse caso, `pinguins`.
 

--- a/data-visualize.qmd
+++ b/data-visualize.qmd
@@ -574,7 +574,7 @@ Não entraremos em detalhes sobre como `geom_density()` estima a densidade (voc�
 Imagine um histograma feito de blocos de madeira.
 Em seguida, imagine que você jogue um fio de espaguete cozido sobre ele.
 A forma que o espaguete assumirá sobre os blocos pode ser considerada como a forma da curva de densidade.
-Ela mostra menos detalhes do que um histograma, mas pode facilitar a obtenção rápida da forma da distribuição, principalmente com relação aos modos e à assimetria.
+Ela mostra menos detalhes do que um histograma, mas pode facilitar a obtenção rápida da forma da distribuição, principalmente com relação à moda (valor que ocorre com maior frequência) e à assimetria.
 
 ```{r}
 #| fig-alt: |

--- a/data-visualize.qmd
+++ b/data-visualize.qmd
@@ -224,7 +224,7 @@ Antes de adicionarmos mais camadas a esse gráfico, vamos parar por um momento e
 
 Estamos vendo essa mensagem porque há dois pinguins em nosso conjunto de dados com valores faltantes (*missing values - *NA*) de massa corporal e/ou comprimento da nadadeira e o ggplot2 não tem como representá-los no gráfico sem esses dois valores.
 Assim como o R, o ggplot2 adota a filosofia de que os valores faltantes nunca devem desaparecer silenciosamente.
-Esse tipo de aviso é provavelmente um dos tipos mais comuns de avisos que você verá ao trabalhar com dados reais - os valores ausentes são um problema muito comum e você aprenderá mais sobre eles ao longo do livro, especialmente em @sec-missing-values.
+Esse tipo de aviso é provavelmente um dos tipos mais comuns de avisos que você verá ao trabalhar com dados reais - os valores faltantes são um problema muito comum e você aprenderá mais sobre eles ao longo do livro, especialmente em @sec-missing-values.
 Nos demais gráficos deste capítulo, suprimiuprimir esse aviso para que ele não seja mostrado em cada gráfico que fizermos.
 
 ### Adicionando atributos estéticos e camadas {#sec-adding-aesthetics-layers}

--- a/data-visualize.qmd
+++ b/data-visualize.qmd
@@ -375,7 +375,7 @@ Finalmente temos um gráfico que corresponde perfeitamente ao nosso "objetivo fi
     Descreva a relação entre essas duas variáveis.
 
 4.  O que acontece se você fizer um gráfico de dispersão de `especie` em função de `profundidade_bico`?
-    Qual seria uma melhor escolha de geometria?
+    Qual seria uma melhor escolha de geometria (*geom*)?
 
 5.  Por que o seguinte erro ocorre e como você poderia corrigi-lo?
 

--- a/data-visualize.qmd
+++ b/data-visualize.qmd
@@ -192,7 +192,7 @@ Nossa tela vazia agora está mais estruturada: está claro onde os comprimentos 
 Mas os pinguins em si ainda não estão no gráfico.
 Isso ocorre porque ainda não definimos, em nosso código, como representar as observações de nosso *data frame* em nosso gráfico.
 
-Para isso, precisamos definir uma **geom**: A geometria que um gráfico usa para representar os dados.
+Para isso, precisamos definir uma **geom**: a geometria que um gráfico usa para representar os dados.
 Essas geometrias são disponibilizados no ggplot2 com funções que começam com `geom_`.
 As pessoas geralmente descrevem os gráficos pelo tipo de geom que o gráfico usa.
 Por exemplo, os gráficos de barras usam geometrias de barras (`geom_bar()`), os gráficos de linhas usam geometrias de linhas (`geom_line()`), os boxplots usam geometrias de boxplot (`geom_boxplot()`), os gráficos de dispersão usam geometrias de pontos (`geom_point()`) e assim por diante.

--- a/data-visualize.qmd
+++ b/data-visualize.qmd
@@ -307,7 +307,7 @@ Pronto!
 Temos algo que se parece muito com nosso objetivo final, embora ainda não esteja perfeito.
 Ainda precisamos usar formas diferentes para cada espécie de pinguim e melhorar os rótulos.
 
-Em geral, não é uma boa ideia representar informações usando apenas cores em um gráfico, pois as pessoas percebem as cores de forma diferente devido ao daltonismo ou a outras diferenças de visão de cores.
+Geralmente, não é uma boa ideia representar informações usando apenas cores em um gráfico, pois as pessoas percebem as cores de forma diferente devido ao daltonismo ou a outras diferenças de visão de cores.
 Portanto, além da cor, também podemos mapear `especie` para a estética `shape` (forma).
 
 ```{r}

--- a/data-visualize.qmd
+++ b/data-visualize.qmd
@@ -134,7 +134,8 @@ Nosso objetivo final neste capítulo é recriar a seguinte visualização que ex
 #|   entre essas duas variáveis sobreposta. O gráfico mostra uma relação 
 #|   positiva, razoavelmente linear e relativamente forte entre essas 
 #|   duas variáveis. As espécies (Pinguim-de-adélia, Pinguim-de-barbicha 
-#|   e Pinguim-gentoo) são representadas com cores e formas diferentes. A #|   relação entre a massa corporal e o comprimento da nadadeira é 
+#|   e Pinguim-gentoo) são representadas com cores e formas diferentes. A 
+#|   relação entre a massa corporal e o comprimento da nadadeira é 
 #|   aproximadamente a mesma para essas três espécies, e os pinguins 
 #|   Gentoo são maiores do que os pinguins das outras duas espécies.
 

--- a/data-visualize.qmd
+++ b/data-visualize.qmd
@@ -237,7 +237,7 @@ Faremos isso representando as espécies com pontos de cores diferentes.
 Para conseguir isso, precisaremos modificar o atributo estético ou a geometria?
 Se você pensou "no mapeamento estético, dentro de `aes()`", você já está pegando o jeito de criar visualizações de dados com o ggplot2!
 Caso contrário, não se preocupe.
-Ao longo do livro, você criará muito mais ggplots e terá muito mais oportunidades de verificar sua intuição ao criá-los.
+Ao longo do livro, você criará muito mais visualizações com ggplot e terá muito mais oportunidades de verificar sua intuição.
 
 ```{r}
 #| warning: false

--- a/data-visualize.qmd
+++ b/data-visualize.qmd
@@ -838,7 +838,7 @@ ggplot(pinguins, aes(x = especie, fill = ilha)) +
 ## Salvando seus gráficos {#sec-ggsave}
 
 Depois de criar um gráfico, talvez você queira tirá-lo do R salvando-o como uma imagem que possa ser usada em outro lugar.
-Essa é a função de `ggsave()`, que salvará no computador o gráfico criado mais recentemente:
+Esse é o objetivo da função `ggsave()`, que salvará no computador o gráfico criado mais recentemente:
 
 ```{r}
 #| fig-show: hide

--- a/data-visualize.qmd
+++ b/data-visualize.qmd
@@ -92,7 +92,7 @@ Para facilitar a discussão, vamos definir alguns termos:
     Às vezes, vamos nos referir a uma observação como um ponto de dados.
 
 -   **Dados tabulares** são um conjunto de valores, cada um associado a uma variável e uma observação.
-    Os dados tabulares estarão no formato ***tidy*** se cada valor estiver em sua própria "célula", cada variável em sua própria coluna e cada observação em sua própria linha.
+    Os dados tabulares estarão no formato *tidy* (arrumado) se cada valor estiver em sua própria "célula", cada variável em sua própria coluna e cada observação em sua própria linha.
 
 Neste contexto, uma variável refere-se a um atributo de todos os pinguins, e uma observação refere-se a todos os atributos de um único pinguim.
 

--- a/data-visualize.qmd
+++ b/data-visualize.qmd
@@ -711,7 +711,7 @@ ggplot(pinguins, aes(x = ilha, fill = especie)) +
 ```
 
 O segundo gráfico é um gráfico de frequência relativa, criado pela definição de `position = "fill"` na geometria, que é mais útil para comparar as distribuições de espécies entre as ilhas, pois não é afetado pelo número desigual de pinguins entre as ilhas.
-Usando esse gráfico, podemos ver que todos os Pinguim-gentoo vivem na ilha Biscoe e constituem aproximadamente 75% dos pinguins dessa ilha, todos os Pinguim-de-barbicha vivem na ilha Dream e constituem aproximadamente 50% dos pinguins dessa ilha, e os Pinguim-de-adélia vivem nas três ilhas e constituem todos os pinguins de Torgersen.
+Usando esse gráfico, podemos ver que todos os Pinguim-gentoo vivem na ilha Biscoe e constituem aproximadamente 75% dos pinguins dessa ilha, todos os Pinguim-de-barbicha vivem na ilha Dream e constituem aproximadamente 50% dos pinguins dessa ilha, e os Pinguim-de-adélia vivem nas três ilhas e constituem todos os pinguins da ilha Torgersen.
 
 ```{r}
 #| fig-alt: |

--- a/data-visualize.qmd
+++ b/data-visualize.qmd
@@ -710,7 +710,7 @@ ggplot(pinguins, aes(x = ilha, fill = especie)) +
   geom_bar()
 ```
 
-O segundo gráfico é um gráfico de frequência relativa, criado pela definição de `position = "fill"` na geom, que é mais útil para comparar as distribuições de espécies entre as ilhas, pois não é afetado pelo número desigual de pinguins entre as ilhas.
+O segundo gráfico é um gráfico de frequência relativa, criado pela definição de `position = "fill"` na geometria, que é mais útil para comparar as distribuições de espécies entre as ilhas, pois não é afetado pelo número desigual de pinguins entre as ilhas.
 Usando esse gráfico, podemos ver que todos os Pinguim-gentoo vivem na ilha Biscoe e constituem aproximadamente 75% dos pinguins dessa ilha, todos os Pinguim-de-barbicha vivem na ilha Dream e constituem aproximadamente 50% dos pinguins dessa ilha, e os Pinguim-de-adélia vivem nas três ilhas e constituem todos os pinguins de Torgersen.
 
 ```{r}

--- a/data-visualize.qmd
+++ b/data-visualize.qmd
@@ -391,7 +391,7 @@ ggplot(data = pinguins) +
     Crie um gráfico de dispersão em que você use esse argumento definido como `TRUE` (verdadeiro).
 
 7.  Adicione a seguinte legenda ao gráfico que você criou no exercício anterior: "Os dados são provenientes do pacote dados".
-    Dica: dê uma olhada na documentação de `labs()`.
+    Dica: dê uma olhada na documentação da função `labs()`.
 
 8.  Recrie a visualização a seguir.
     Para qual atributo estético `profundidade_bico` deve ser mapeada?

--- a/data-visualize.qmd
+++ b/data-visualize.qmd
@@ -235,7 +235,7 @@ Vamos incluir as espécies em nosso gráfico e ver se isso revela alguma ideia a
 Faremos isso representando as espécies com pontos de cores diferentes.
 
 Para conseguir isso, precisaremos modificar o atributo estético ou a geometria?
-Se você adivinhou "no mapeamento estético, dentro de `aes()`", você já está pegando o jeito de criar visualizações de dados com o ggplot2!
+Se você pensou "no mapeamento estético, dentro de `aes()`", você já está pegando o jeito de criar visualizações de dados com o ggplot2!
 Caso contrário, não se preocupe.
 Ao longo do livro, você criará muito mais ggplots e terá muito mais oportunidades de verificar sua intuição ao criá-los.
 

--- a/data-visualize.qmd
+++ b/data-visualize.qmd
@@ -153,7 +153,7 @@ ggplot(pinguins, aes(x = comprimento_nadadeira, y = massa_corporal)) +
   scale_color_colorblind()
 ```
 
-### Criando um ggplot
+### Criando um gráfico ggplot
 
 Vamos recriar esse gráfico passo a passo.
 

--- a/data-visualize.qmd
+++ b/data-visualize.qmd
@@ -466,7 +466,7 @@ ggplot(
   geom_point()
 ```
 
-Normalmente, o primeiro ou os dois primeiros argumentos de uma função são tão importantes que você deve sabê-los de cor.
+Normalmente, o primeiro ou os dois primeiros argumentos de uma função são tão importantes que você deve saber usar de cor.
 Os dois primeiros argumentos de `ggplot()` são `data` e `mapping`; no restante do livro, não forneceremos esses nomes.
 Isso economiza digitação e, ao reduzir a quantidade de texto extra, facilita a visualização das diferenças entre os gráficos.
 Essa é uma preocupação de programação realmente importante, à qual voltaremos em @sec-functions.

--- a/data-visualize.qmd
+++ b/data-visualize.qmd
@@ -98,7 +98,7 @@ Neste contexto, uma variável refere-se a um atributo de todos os pinguins, e um
 
 Digite o nome do *data frame* no console e o R mostrará uma visualização de seu conteúdo.
 Observe que aparece escrito `tibble` no topo desta visualização.
-No tidyverse, usamos *data frames* especiais chamados ***tibbles***, dos quais você aprenderá mais em breve.
+No tidyverse, usamos *data frames* especiais chamados **tibbles**, dos quais você aprenderá mais em breve.
 
 ```{r}
 pinguins

--- a/data-visualize.qmd
+++ b/data-visualize.qmd
@@ -676,7 +676,8 @@ Como alternativa, podemos criar gráficos de densidade com `geom_density()`.
 #| fig-alt: |
 #|   Um gráfico de densidade da massa corporal de pinguins separado por 
 #|   espécie. Cada espécie (Pinguim-de-adélia, Pinguim-de-barbicha e 
-#|   Pinguim-gentoo) é representada por um contorno colorido diferente em #|   cada curva de densidade.
+#|   Pinguim-gentoo) é representada por um contorno colorido diferente em
+#|   cada curva de densidade.
 
 ggplot(pinguins, aes(x = massa_corporal, color = especie)) +
   geom_density(linewidth = 0.75)

--- a/data-visualize.qmd
+++ b/data-visualize.qmd
@@ -761,7 +761,7 @@ ggplot(pinguins, aes(x = comprimento_nadadeira, y = massa_corporal)) +
   geom_point(aes(color = especie, shape = ilha))
 ```
 
-No entanto, mapear muitos atirbutos estéticos a um gráfico faz com que ele fique desordenado e difícil de entender.
+No entanto, mapear muitos atributos estéticos a um gráfico faz com que ele fique desordenado e difícil de entender.
 Outra maneira, que é particularmente útil para variáveis categóricas, é dividir seu gráfico em **facetas**, subdivisões que exibem um subconjunto dos dados cada uma.
 
 Para separar seu gráfico em facetas por uma única variável, use `facet_wrap()`.

--- a/data-visualize.qmd
+++ b/data-visualize.qmd
@@ -6,23 +6,23 @@
 source("_common.R")
 ```
 
-## Introduction
+## Introdução
 
-> "The simple graph has brought more information to the data analyst's mind than any other device." --- John Tukey
+> "O gráfico simples trouxe mais informações à mente dos analistas de dados do que qualquer outro dispositivo." --- John Tukey
 
-R has several systems for making graphs, but ggplot2 is one of the most elegant and most versatile.
-ggplot2 implements the **grammar of graphics**, a coherent system for describing and building graphs.
-With ggplot2, you can do more and faster by learning one system and applying it in many places.
+O R possui diversos sistemas para construir gráficos, mas o ggplot2 é um dos mais elegantes e versáteis.
+O ggplot2 implementa a **gramática dos gráficos**, um sistema coerente para descrever e construir gráficos.
+Com o ggplot2 você pode fazer mais rápido, ao aprender um sistema e aplicá-lo em muitos lugares.
 
-This chapter will teach you how to visualize your data using **ggplot2**.
-We will start by creating a simple scatterplot and use that to introduce aesthetic mappings and geometric objects -- the fundamental building blocks of ggplot2.
-We will then walk you through visualizing distributions of single variables as well as visualizing relationships between two or more variables.
-We'll finish off with saving your plots and troubleshooting tips.
+Este capítulo irá te ensinar como visualizar seus dados usando o **ggplot2**.
+Nós vamos começar criando um gráfico de dispersão simples e usá-lo para introduzir o mapeamento de atributos estéticos (*aesthetic*) e geometrias -- os blocos fundamentais na construção do ggplot2.
+Nós vamos então te orientar na visualização de distribuições de variáveis individuais, bem como na visualização de relações entre duas ou mais variáveis.
+Terminaremos salvando seus gráficos e com dicas de resolução de problemas.
 
-### Prerequisites
+### Pré-requisitos
 
-This chapter focuses on ggplot2, one of the core packages in the tidyverse.
-To access the datasets, help pages, and functions used in this chapter, load the tidyverse by running:
+Este capítulo tem foco no ggplot2, um dos pacotes principais do tidyverse.
+Para acessar os bancos de dados, páginas de ajuda e funções utilizadas neste capítulo, carregue o tidyverse executando:
 
 ```{r}
 #| label: setup
@@ -30,13 +30,13 @@ To access the datasets, help pages, and functions used in this chapter, load the
 library(tidyverse)
 ```
 
-That one line of code loads the core tidyverse; the packages that you will use in almost every data analysis.
-It also tells you which functions from the tidyverse conflict with functions in base R (or from other packages you might have loaded)[^data-visualize-1].
+Essa única linha de código carrega o essencial do tidyverse; os pacotes que você irá utilizar em quase toda análise de dados.
+Ela também te diz quais funções do tidyverse possuem conflitos com as função do R base (ou de outro pacote que você tenha carregado)[^data-visualize-1].
 
-[^data-visualize-1]: You can eliminate that message and force conflict resolution to happen on demand by using the conflicted package, which becomes more important as you load more packages.
-    You can learn more about conflicted at <https://conflicted.r-lib.org>.
+[^data-visualize-1]: Você pode eliminar essa mensagem e forçar com que a resolução de conflitos aconteça sob demanda utilizando o pacote conflicted, que se torna mais importante à medida que carrega mais pacotes.
+    Você pode ler mais sobre o pacote conflicted em <https://conflicted.r-lib.org>.
 
-If you run this code and get the error message `there is no package called 'tidyverse'`, you'll need to first install it, then run `library()` once again.
+Se você rodar este código e receber a mensagem de erro `there is no package called 'tidyverse'`, você precisará instalar o pacote antes, e então rodar `library()` novamente.
 
 ```{r}
 #| eval: false
@@ -45,135 +45,136 @@ install.packages("tidyverse")
 library(tidyverse)
 ```
 
-You only need to install a package once, but you need to load it every time you start a new session.
+Você só precisa instalar um pacote uma vez, mas precisa carregá-lo sempre que iniciar uma nova sessão.
 
-In addition to tidyverse, we will also use the **palmerpenguins** package, which includes the `penguins` dataset containing body measurements for penguins on three islands in the Palmer Archipelago, and the ggthemes package, which offers a colorblind safe color palette.
+Além do tidyverse, nós também usaremos o pacote **dados**, que inclui um banco de dados com medidas corporais de pinguins de três ilhas do Arquipélago Palmer, junto do pacote ggthemes, que fornece uma paleta de cores segura para daltônicos.
 
 ```{r}
-library(palmerpenguins)
+library(dados)
 library(ggthemes)
 ```
 
-## First steps
+## Primeiros passos
 
-Do penguins with longer flippers weigh more or less than penguins with shorter flippers?
-You probably already have an answer, but try to make your answer precise.
-What does the relationship between flipper length and body mass look like?
-Is it positive?
-Negative?
+Os pinguins com nadadeiras mais compridas pesam mais ou menos que pinguins com nadadeiras curtas?
+Você provavelmentejá tem uma resposta, mas tente torná-la mais precisa.
+Como é a relação entre o comprimento da nadadeira e massa corporal?
+Ela é positiva?
+Negativa?
 Linear?
-Nonlinear?
-Does the relationship vary by the species of the penguin?
-How about by the island where the penguin lives?
-Let's create visualizations that we can use to answer these questions.
+Não linear?
+A relação varia com a espécie do pinguim?
+E quanto à ilha onde o pinguim vive?
+Vamos criar visualizações que podemos usar para responder essas perguntas.
 
-### The `penguins` data frame
+### O data frame `pinguins`
 
-You can test your answers to those questions with the `penguins` **data frame** found in palmerpenguins (a.k.a. `palmerpenguins::penguins`).
-A data frame is a rectangular collection of variables (in the columns) and observations (in the rows).
-`penguins` contains `r nrow(penguins)` observations collected and made available by Dr. Kristen Gorman and the Palmer Station, Antarctica LTER[^data-visualize-2].
+Você pode testar suas respostas à essas questões usando o **data frame** `pinguins` encontrado no pacote `dados` (usando `dados::pinguins`).
+Um *data frame* é uma coleção retangular de variáveis (nas colunas) e observações (nas linhas).
+`pinguins` contém `r nrow(pinguins)` observações coletadas e disponibilizadas pela Dra.
+Kristen Gorman e pelo PELD Estação Palmer, Antártica[^data-visualize-2].
 
 [^data-visualize-2]: Horst AM, Hill AP, Gorman KB (2020).
-    palmerpenguins: Palmer Archipelago (Antarctica) penguin data.
+    palmerpinguins: Palmer Archipelago (Antarctica) penguin data.
     R package version 0.1.0.
-    <https://allisonhorst.github.io/palmerpenguins/>.
+    <https://allisonhorst.github.io/palmerpinguins/>.
     doi: 10.5281/zenodo.3960218.
 
-To make the discussion easier, let's define some terms:
+Para facilitar a discussão, vamos definir alguns termos:
 
--   A **variable** is a quantity, quality, or property that you can measure.
+-   Uma **variável** é uma quantidade, qualidade ou propriedade que você pode medir.
 
--   A **value** is the state of a variable when you measure it.
-    The value of a variable may change from measurement to measurement.
+-   Um **valor** é o estado de uma variável quando você a mede.
+    O valor de uma variável pode mudar de medição para medição.
 
--   An **observation** is a set of measurements made under similar conditions (you usually make all of the measurements in an observation at the same time and on the same object).
-    An observation will contain several values, each associated with a different variable.
-    We'll sometimes refer to an observation as a data point.
+-   Uma **observação** é um conjunto de medições feitas em condições semelhantes (geralmente todas as medições em uma observação são feitas ao mesmo tempo e no mesmo objeto).
+    Uma **observação** conterá vários valores, cada um associado a uma variável diferente.
+    Às vezes, vamos nos referir a uma observação como um ponto de dados.
 
--   **Tabular data** is a set of values, each associated with a variable and an observation.
-    Tabular data is *tidy* if each value is placed in its own "cell", each variable in its own column, and each observation in its own row.
+-   **Dados tabulares** são um conjunto de valores, cada um associado a uma variável e uma observação.
+    Os dados tabulares estarão no formato ***tidy*** se cada valor estiver em sua própria "célula", cada variável em sua própria coluna e cada observação em sua própria linha.
 
-In this context, a variable refers to an attribute of all the penguins, and an observation refers to all the attributes of a single penguin.
+Neste contexto, uma variável refere-se a um atributo de todos os pinguins, e uma observação refere-se a todos os atributos de um único pinguim.
 
-Type the name of the data frame in the console and R will print a preview of its contents.
-Note that it says `tibble` on top of this preview.
-In the tidyverse, we use special data frames called **tibbles** that you will learn more about soon.
-
-```{r}
-penguins
-```
-
-This data frame contains `r ncol(penguins)` columns.
-For an alternative view, where you can see all variables and the first few observations of each variable, use `glimpse()`.
-Or, if you're in RStudio, run `View(penguins)` to open an interactive data viewer.
+Digite o nome do *data frame* no console e o R mostrará uma visualização de seu conteúdo.
+Observe que aparece escrito `tibble` no topo desta visualização.
+No tidyverse, usamos *data frames* especiais chamados ***tibbles***, dos quais você aprenderá mais em breve.
 
 ```{r}
-glimpse(penguins)
+pinguins
 ```
 
-Among the variables in `penguins` are:
+Este *data frame* contém `r ncol(pinguins)` colunas.
+Para uma visualização alternativa, onde você pode ver todas as variáveis e as primeiras observações de cada variável, use `glimpse()`.
+Ou, se você estiver no RStudio, execute `View(pinguins)` para abrir um visualizador de dados interativo.
 
-1.  `species`: a penguin's species (Adelie, Chinstrap, or Gentoo).
+```{r}
+glimpse(pinguins)
+```
 
-2.  `flipper_length_mm`: length of a penguin's flipper, in millimeters.
+Entre as variáveis em pinguins estão:
 
-3.  `body_mass_g`: body mass of a penguin, in grams.
+1.  `especie`: a espécie de um pinguim (Pinguim-de-adélia, Pinguim-de-barbicha e Pinguim-gentoo).
 
-To learn more about `penguins`, open its help page by running `?penguins`.
+2.  `comprimento_nadadeira`: comprimento da nadadeira de um pinguim, em milímetros.
 
-### Ultimate goal {#sec-ultimate-goal}
+3.  `massa_corporal`: massa corporal de um pinguim, em gramas.
 
-Our ultimate goal in this chapter is to recreate the following visualization displaying the relationship between flipper lengths and body masses of these penguins, taking into consideration the species of the penguin.
+Para saber mais sobre `pinguins`, abra sua página de ajuda executando `?pinguins`.
+
+### Objetivo final {#sec-ultimate-goal}
+
+Nosso objetivo final neste capítulo é recriar a seguinte visualização que exibe a relação entre o comprimento da nadadeira e a massa corporal desses pinguins, levando em consideração a espécie do pinguim.
 
 ```{r}
 #| echo: false
 #| warning: false
 #| fig-alt: |
-#|   A scatterplot of body mass vs. flipper length of penguins, with a
+#|   A scatterplot of body mass vs. flipper length of pinguins, with a
 #|   best fit line of the relationship between these two variables 
 #|   overlaid. The plot displays a positive, fairly linear, and relatively 
-#|   strong relationship between these two variables. Species (Adelie, 
+#|   strong relationship between these two variables. especie (Adelie, 
 #|   Chinstrap, and Gentoo) are represented with different colors and 
 #|   shapes. The relationship between body mass and flipper length is 
-#|   roughly the same for these three species, and Gentoo penguins are 
-#|   larger than penguins from the other two species.
+#|   roughly the same for these three especie, and Gentoo pinguins are 
+#|   larger than pinguins from the other two especie.
 
-ggplot(penguins, aes(x = flipper_length_mm, y = body_mass_g)) +
-  geom_point(aes(color = species, shape = species)) +
+ggplot(pinguins, aes(x = comprimento_nadadeira, y = massa_corporal)) +
+  geom_point(aes(color = especie, shape = especie)) +
   geom_smooth(method = "lm") +
   labs(
-    title = "Body mass and flipper length",
-    subtitle = "Dimensions for Adelie, Chinstrap, and Gentoo Penguins",
-    x = "Flipper length (mm)",
-    y = "Body mass (g)",
-    color = "Species",
-    shape = "Species"
+    title = "Massa corporal e comprimento da nadadeira",
+    subtitle = "Medidas para Pinguim-de-adélia, Pinguim-de-barbicha e Pinguim-gentoo",
+    x = "Comprimento da nadadeira (mm)",
+    y = "Massa corporal (g)",
+    color = "Espécie",
+    shape = "Espécie"
   ) +
   scale_color_colorblind()
 ```
 
-### Creating a ggplot
+### Criando um ggplot
 
-Let's recreate this plot step-by-step.
+Vamos recriar esse gráfico passo a passo.
 
-With ggplot2, you begin a plot with the function `ggplot()`, defining a plot object that you then add **layers** to.
-The first argument of `ggplot()` is the dataset to use in the graph and so `ggplot(data = penguins)` creates an empty graph that is primed to display the `penguins` data, but since we haven't told it how to visualize it yet, for now it's empty.
-This is not a very exciting plot, but you can think of it like an empty canvas you'll paint the remaining layers of your plot onto.
+Com o ggplot2, você inicia um gráfico com a função `ggplot()`, definindo um objeto de gráfico ao qual você adiciona **camadas**.
+O primeiro argumento de `ggplot()` é o conjunto de dados a ser usado no gráfico e, portanto, `ggplot(data = pinguins)` cria um gráfico vazio que está preparado para exibir os dados dos `pinguins`, mas, como ainda não dissemos como visualizá-los, por enquanto ele está vazio.
+Esse não é um gráfico muito interessante, mas você pode pensar nele como uma tela vazia na qual você pintará as camadas restantes do seu gráfico.
 
 ```{r}
 #| fig-alt: |
-#|   A blank, gray plot area.
+#|   Uma área de gráfico vazia em cinza
 
-ggplot(data = penguins)
+ggplot(data = pinguins)
 ```
 
-Next, we need to tell `ggplot()` how the information from our data will be visually represented.
-The `mapping` argument of the `ggplot()` function defines how variables in your dataset are mapped to visual properties (**aesthetics**) of your plot.
-The `mapping` argument is always defined in the `aes()` function, and the `x` and `y` arguments of `aes()` specify which variables to map to the x and y axes.
-For now, we will only map flipper length to the `x` aesthetic and body mass to the `y` aesthetic.
-ggplot2 looks for the mapped variables in the `data` argument, in this case, `penguins`.
+Em seguida, precisamos informar ao `ggplot()` como as informações dos nossos dados serão representadas visualmente.
+O argumento `mapping` (mapeamento) da função `ggplot()` define como as variáveis em seu conjunto de dados são mapeadas para as propriedades visuais (**estética**) do gráfico.
+O argumento `mapping` é sempre definido na função `aes()`, e os argumentos `x` e `y` de `aes()` especificam quais variáveis devem ser mapeadas para os eixos x e y.
+Por enquanto, mapearemos apenas o comprimento da nadadeira para o atributo estético `x` e a massa corporal para o atributo `y`.
+O ggplot2 procura as variáveis mapeadas no argumento `data`, nesse caso, `pinguins`.
 
-The following plot shows the result of adding these mappings.
+O gráfico a seguir mostra o resultado da adição desses mapeamentos.
 
 ```{r}
 #| fig-alt: |
@@ -182,453 +183,452 @@ The following plot shows the result of adding these mappings.
 #|   to 6000.
 
 ggplot(
-  data = penguins,
-  mapping = aes(x = flipper_length_mm, y = body_mass_g)
+  data = pinguins,
+  mapping = aes(x = comprimento_nadadeira, y = massa_corporal)
 )
 ```
 
-Our empty canvas now has more structure -- it's clear where flipper lengths will be displayed (on the x-axis) and where body masses will be displayed (on the y-axis).
-But the penguins themselves are not yet on the plot.
-This is because we have not yet articulated, in our code, how to represent the observations from our data frame on our plot.
+Nossa tela vazia agora tem mais estrutura: está claro onde os comprimentos das nadadeiras serão exibidos (no eixo x) e onde as massas corporais serão exibidas (no eixo y).
+Mas os pinguins em si ainda não estão no gráfico.
+Isso ocorre porque ainda não definimos, em nosso código, como representar as observações de nosso *data frame* em nosso gráfico.
 
-To do so, we need to define a **geom**: the geometrical object that a plot uses to represent data.
-These geometric objects are made available in ggplot2 with functions that start with `geom_`.
-People often describe plots by the type of geom that the plot uses.
-For example, bar charts use bar geoms (`geom_bar()`), line charts use line geoms (`geom_line()`), boxplots use boxplot geoms (`geom_boxplot()`), scatterplots use point geoms (`geom_point()`), and so on.
+Para isso, precisamos definir uma **geom**: A geometria que um gráfico usa para representar os dados.
+Essas geometrias são disponibilizados no ggplot2 com funções que começam com `geom_`.
+As pessoas geralmente descrevem os gráficos pelo tipo de geom que o gráfico usa.
+Por exemplo, os gráficos de barras usam geometrias de barras (`geom_bar()`), os gráficos de linhas usam geometrias de linhas (`geom_line()`), os boxplots usam geometrias de boxplot (`geom_boxplot()`), os gráficos de dispersão usam geometrias de pontos (`geom_point()`) e assim por diante.
 
-The function `geom_point()` adds a layer of points to your plot, which creates a scatterplot.
-ggplot2 comes with many geom functions that each adds a different type of layer to a plot.
-You'll learn a whole bunch of geoms throughout the book, particularly in @sec-layers.
+A função `geom_point()` adiciona uma camada de pontos ao seu gráfico, o que cria um gráfico de dispersão.
+O ggplot2 vem com muitas funções de geometria, cada uma adicionando um tipo diferente de camada a um gráfico.
+Você aprenderá várias geometrias ao longo do livro, principalmente em @sec-layers.
 
 ```{r}
 #| fig-alt: |
-#|   A scatterplot of body mass vs. flipper length of penguins. The plot 
+#|   A scatterplot of body mass vs. flipper length of pinguins. The plot 
 #|   displays a positive, linear, and relatively strong relationship between 
 #|   these two variables.
 
 ggplot(
-  data = penguins,
-  mapping = aes(x = flipper_length_mm, y = body_mass_g)
+  data = pinguins,
+  mapping = aes(x = comprimento_nadadeira, y = massa_corporal)
 ) +
   geom_point()
 ```
 
-Now we have something that looks like what we might think of as a "scatterplot".
-It doesn't yet match our "ultimate goal" plot, but using this plot we can start answering the question that motivated our exploration: "What does the relationship between flipper length and body mass look like?" The relationship appears to be positive (as flipper length increases, so does body mass), fairly linear (the points are clustered around a line instead of a curve), and moderately strong (there isn't too much scatter around such a line).
-Penguins with longer flippers are generally larger in terms of their body mass.
+Agora temos algo que se parece com o que poderíamos chamar de "gráfico de dispersão".
+Ele ainda não corresponde ao nosso gráfico de "objetivo final", mas, usando esse gráfico, podemos começar a responder à pergunta que motivou nossa exploração: "Como é a relação entre o comprimento da nadadeira e a massa corporal?" A relação parece ser positiva (à medida que o comprimento da nadadeira aumenta, a massa corporal também aumenta), razoavelmente linear (os pontos estão agrupados em torno de uma linha em vez de uma curva) e moderadamente forte (não há muita dispersão em torno dessa linha).
+Os pinguins com nadadeiras mais longas geralmente são maiores em termos de massa corporal.
 
-Before we add more layers to this plot, let's pause for a moment and review the warning message we got:
+Antes de adicionarmos mais camadas a esse gráfico, vamos parar por um momento e revisar a mensagem de aviso que recebemos:
 
 > Removed 2 rows containing missing values (`geom_point()`).
 
-We're seeing this message because there are two penguins in our dataset with missing body mass and/or flipper length values and ggplot2 has no way of representing them on the plot without both of these values.
-Like R, ggplot2 subscribes to the philosophy that missing values should never silently go missing.
-This type of warning is probably one of the most common types of warnings you will see when working with real data -- missing values are a very common issue and you'll learn more about them throughout the book, particularly in @sec-missing-values.
-For the remaining plots in this chapter we will suppress this warning so it's not printed alongside every single plot we make.
+Estamos vendo essa mensagem porque há dois pinguins em nosso conjunto de dados com valores ausentes de massa corporal e/ou comprimento da nadadeira e o ggplot2 não tem como representá-los no gráfico sem esses dois valores.
+Assim como o R, o ggplot2 adota a filosofia de que os valores ausentes nunca devem desaparecer silenciosamente.
+Esse tipo de aviso é provavelmente um dos tipos mais comuns de avisos que você verá ao trabalhar com dados reais - os valores ausentes são um problema muito comum e você aprenderá mais sobre eles ao longo do livro, especialmente em @sec-missing-values.
+Nos demais gráficos deste capítulo, suprimiuprimir esse aviso para que ele não seja mostrado em cada gráfico que fizermos.
 
-### Adding aesthetics and layers {#sec-adding-aesthetics-layers}
+### Adicionando atributos estéticos e camadas {#sec-adding-aesthetics-layers}
 
-Scatterplots are useful for displaying the relationship between two numerical variables, but it's always a good idea to be skeptical of any apparent relationship between two variables and ask if there may be other variables that explain or change the nature of this apparent relationship.
-For example, does the relationship between flipper length and body mass differ by species?
-Let's incorporate species into our plot and see if this reveals any additional insights into the apparent relationship between these variables.
-We will do this by representing species with different colored points.
+Gráficos de dispersão são úteis para exibir a relação entre duas variáveis numéricas, mas é sempre uma boa ideia ser cético em relação a qualquer relação aparente entre duas variáveis e perguntar se pode haver outras variáveis que expliquem ou mudem a natureza dessa relação aparente.
+Por exemplo, a relação entre o comprimento das nadadeira e a massa corporal difere de acordo com a espécie?
+Vamos incluir as espécies em nosso gráfico e ver se isso revela alguma ideia adicional sobre a relação aparente entre essas variáveis.
+Faremos isso representando as espécies com pontos de cores diferentes.
 
-To achieve this, will we need to modify the aesthetic or the geom?
-If you guessed "in the aesthetic mapping, inside of `aes()`", you're already getting the hang of creating data visualizations with ggplot2!
-And if not, don't worry.
-Throughout the book you will make many more ggplots and have many more opportunities to check your intuition as you make them.
+Para conseguir isso, precisaremos modificar o atributo estético ou a geometria?
+Se você adivinhou "no mapeamento estético, dentro de `aes()`", você já está pegando o jeito de criar visualizações de dados com o ggplot2!
+Caso contrário, não se preocupe.
+Ao longo do livro, você criará muito mais ggplots e terá muito mais oportunidades de verificar sua intuição ao criá-los.
 
 ```{r}
 #| warning: false
 #| fig-alt: |
-#|   A scatterplot of body mass vs. flipper length of penguins. The plot 
+#|   A scatterplot of body mass vs. flipper length of pinguins. The plot 
 #|   displays a positive, fairly linear, and relatively strong relationship 
-#|   between these two variables. Species (Adelie, Chinstrap, and Gentoo) 
+#|   between these two variables. especie (Adelie, Chinstrap, and Gentoo) 
 #|   are represented with different colors.
 
 ggplot(
-  data = penguins,
-  mapping = aes(x = flipper_length_mm, y = body_mass_g, color = species)
+  data = pinguins,
+  mapping = aes(x = comprimento_nadadeira, y = massa_corporal, color = especie)
 ) +
   geom_point()
 ```
 
-When a categorical variable is mapped to an aesthetic, ggplot2 will automatically assign a unique value of the aesthetic (here a unique color) to each unique level of the variable (each of the three species), a process known as **scaling**.
-ggplot2 will also add a legend that explains which values correspond to which levels.
+Quando uma variável categórica é mapeada a um atributo estético, o ggplot2 atribui automaticamente um valor único da estética (aqui uma cor única) a cada nível único da variável (cada uma das três espécies), um processo conhecido como **dimensionamento**.
+O ggplot2 também adicionará uma legenda que explica quais valores correspondem a quais níveis.
 
-Now let's add one more layer: a smooth curve displaying the relationship between body mass and flipper length.
-Before you proceed, refer back to the code above, and think about how we can add this to our existing plot.
+Agora vamos adicionar mais uma camada: uma curva suave que exibe a relação entre a massa corporal e o comprimento das nadadeiras.
+Antes de prosseguir, consulte o código acima e pense em como podemos adicionar isso ao nosso gráfico existente.
 
-Since this is a new geometric object representing our data, we will add a new geom as a layer on top of our point geom: `geom_smooth()`.
-And we will specify that we want to draw the line of best fit based on a `l`inear `m`odel with `method = "lm"`.
+Como esse é uma nova geometria que representa nossos dados, adicionaremos uma nova geometria como uma camada sobre o nossa geometria de pontos: `geom_smooth()`.
+E especificaremos que queremos desenhar a linha de melhor ajuste com base em um modelo linear (`l`inear `m`odel em inglês) com `method = "lm"`.
 
 ```{r}
 #| warning: false
 #| fig-alt: |
-#|   A scatterplot of body mass vs. flipper length of penguins. Overlaid 
+#|   A scatterplot of body mass vs. flipper length of pinguins. Overlaid 
 #|   on the scatterplot are three smooth curves displaying the 
-#|   relationship between these variables for each species (Adelie, 
-#|   Chinstrap, and Gentoo). Different penguin species are plotted in 
+#|   relationship between these variables for each especie (Adelie, 
+#|   Chinstrap, and Gentoo). Different penguin especie are plotted in 
 #|   different colors for the points and the smooth curves.
 
 ggplot(
-  data = penguins,
-  mapping = aes(x = flipper_length_mm, y = body_mass_g, color = species)
+  data = pinguins,
+  mapping = aes(x = comprimento_nadadeira, y = massa_corporal, color = especie)
 ) +
   geom_point() +
   geom_smooth(method = "lm")
 ```
 
-We have successfully added lines, but this plot doesn't look like the plot from @sec-ultimate-goal, which only has one line for the entire dataset as opposed to separate lines for each of the penguin species.
+Adicionamos linhas com sucesso, mas esse gráfico não se parece com o gráfico do @sec-ultimate-goal, que tem apenas uma linha para todo o conjunto de dados, em vez de linhas separadas para cada espécie de pinguim.
 
-When aesthetic mappings are defined in `ggplot()`, at the *global* level, they're passed down to each of the subsequent geom layers of the plot.
-However, each geom function in ggplot2 can also take a `mapping` argument, which allows for aesthetic mappings at the *local* level that are added to those inherited from the global level.
-Since we want points to be colored based on species but don't want the lines to be separated out for them, we should specify `color = species` for `geom_point()` only.
+Quando os mapeamentos estéticos são definidos em `ggplot()`, no nível *global*, eles são passados para cada uma das camadas geom subsequentes do gráfico.
+Entretanto, cada função geom no ggplot2 também pode receber um argumento `mapping`, que permite mapeamentos estéticos em nível *local* que são adicionados àqueles herdados do nível global.
+Como queremos que os pontos sejam coloridos com base na espécie, mas não queremos que as linhas sejam separadas para eles, devemos especificar `color = especie` somente para `geom_point()`.
 
 ```{r}
 #| warning: false
 #| fig-alt: |
-#|   A scatterplot of body mass vs. flipper length of penguins. Overlaid 
+#|   A scatterplot of body mass vs. flipper length of pinguins. Overlaid 
 #|   on the scatterplot is a single line of best fit displaying the 
-#|   relationship between these variables for each species (Adelie, 
-#|   Chinstrap, and Gentoo). Different penguin species are plotted in 
+#|   relationship between these variables for each especie (Adelie, 
+#|   Chinstrap, and Gentoo). Different penguin especie are plotted in 
 #|   different colors for the points only.
 
 ggplot(
-  data = penguins,
-  mapping = aes(x = flipper_length_mm, y = body_mass_g)
+  data = pinguins,
+  mapping = aes(x = comprimento_nadadeira, y = massa_corporal)
 ) +
-  geom_point(mapping = aes(color = species)) +
+  geom_point(mapping = aes(color = especie)) +
   geom_smooth(method = "lm")
 ```
 
-Voila!
-We have something that looks very much like our ultimate goal, though it's not yet perfect.
-We still need to use different shapes for each species of penguins and improve labels.
+Pronto!
+Temos algo que se parece muito com nosso objetivo final, embora ainda não esteja perfeito.
+Ainda precisamos usar formas diferentes para cada espécie de pinguim e melhorar os rótulos.
 
-It's generally not a good idea to represent information using only colors on a plot, as people perceive colors differently due to color blindness or other color vision differences.
-Therefore, in addition to color, we can also map `species` to the `shape` aesthetic.
+Em geral, não é uma boa ideia representar informações usando apenas cores em um gráfico, pois as pessoas percebem as cores de forma diferente devido ao daltonismo ou a outras diferenças de visão de cores.
+Portanto, além da cor, também podemos mapear `especie` para a estética `shape` (forma).
 
 ```{r}
 #| warning: false
 #| fig-alt: |
-#|   A scatterplot of body mass vs. flipper length of penguins. Overlaid 
+#|   A scatterplot of body mass vs. flipper length of pinguins. Overlaid 
 #|   on the scatterplot is a single line of best fit displaying the 
-#|   relationship between these variables for each species (Adelie, 
-#|   Chinstrap, and Gentoo). Different penguin species are plotted in 
+#|   relationship between these variables for each especie (Adelie, 
+#|   Chinstrap, and Gentoo). Different penguin especie are plotted in 
 #|   different colors and shapes for the points only.
 
 ggplot(
-  data = penguins,
-  mapping = aes(x = flipper_length_mm, y = body_mass_g)
+  data = pinguins,
+  mapping = aes(x = comprimento_nadadeira, y = massa_corporal)
 ) +
-  geom_point(mapping = aes(color = species, shape = species)) +
+  geom_point(mapping = aes(color = especie, shape = especie)) +
   geom_smooth(method = "lm")
 ```
 
-Note that the legend is automatically updated to reflect the different shapes of the points as well.
+Observe que a legenda também é atualizada automaticamente para refletir as diferentes formas dos pontos.
 
-And finally, we can improve the labels of our plot using the `labs()` function in a new layer.
-Some of the arguments to `labs()` might be self explanatory: `title` adds a title and `subtitle` adds a subtitle to the plot.
-Other arguments match the aesthetic mappings, `x` is the x-axis label, `y` is the y-axis label, and `color` and `shape` define the label for the legend.
-In addition, we can improve the color palette to be colorblind safe with the `scale_color_colorblind()` function from the ggthemes package.
+E, finalmente, podemos melhorar os rótulos do nosso gráfico usando a função `labs()` em uma nova camada.
+Alguns dos argumentos de `labs()` podem ser autoexplicativos: `title` adiciona um título e `subtitle` adiciona um subtítulo ao gráfico.
+Outros argumentos correspondem aos mapeamentos estéticos, `x` é o rótulo do eixo x, `y` é o rótulo do eixo y e `color` e `shape` definem o rótulo da legenda.
+Além disso, podemos aprimorar a paleta de cores para que seja segura para daltônicos com a função `scale_color_colorblind()` do pacote ggthemes.
 
 ```{r}
 #| warning: false
 #| fig-alt: |
-#|   A scatterplot of body mass vs. flipper length of penguins, with a 
+#|   A scatterplot of body mass vs. flipper length of pinguins, with a 
 #|   line of best fit displaying the relationship between these two variables 
 #|   overlaid. The plot displays a positive, fairly linear, and relatively 
-#|   strong relationship between these two variables. Species (Adelie, 
+#|   strong relationship between these two variables. especie (Adelie, 
 #|   Chinstrap, and Gentoo) are represented with different colors and 
 #|   shapes. The relationship between body mass and flipper length is 
-#|   roughly the same for these three species, and Gentoo penguins are 
-#|   larger than penguins from the other two species.
+#|   roughly the same for these three especie, and Gentoo pinguins are 
+#|   larger than pinguins from the other two especie.
 
-ggplot(
-  data = penguins,
-  mapping = aes(x = flipper_length_mm, y = body_mass_g)
-) +
-  geom_point(aes(color = species, shape = species)) +
+ggplot(pinguins, aes(x = comprimento_nadadeira, y = massa_corporal)) +
+  geom_point(aes(color = especie, shape = especie)) +
   geom_smooth(method = "lm") +
   labs(
-    title = "Body mass and flipper length",
-    subtitle = "Dimensions for Adelie, Chinstrap, and Gentoo Penguins",
-    x = "Flipper length (mm)", y = "Body mass (g)",
-    color = "Species", shape = "Species"
+    title = "Massa corporal e comprimento da nadadeira",
+    subtitle = "Medidas para Pinguim-de-adélia, Pinguim-de-barbicha e Pinguim-gentoo",
+    x = "Comprimento da nadadeira (mm)",
+    y = "Massa corporal (g)",
+    color = "Espécie",
+    shape = "Espécie"
   ) +
   scale_color_colorblind()
 ```
 
-We finally have a plot that perfectly matches our "ultimate goal"!
+Finalmente temos um gráfico que corresponde perfeitamente ao nosso "objetivo final"!
 
-### Exercises
+### Exercícios
 
-1.  How many rows are in `penguins`?
-    How many columns?
+1.  Quantas linhas existem em `pinguins`?
+    E quantas colunas?
 
-2.  What does the `bill_depth_mm` variable in the `penguins` data frame describe?
-    Read the help for `?penguins` to find out.
+2.  O que a variável `profundidade_bico` no *data frame* `pinguins` descreve?
+    Leia a ajuda do `?pinguins` para descobrir.
 
-3.  Make a scatterplot of `bill_depth_mm` vs. `bill_length_mm`.
-    That is, make a scatterplot with `bill_depth_mm` on the y-axis and `bill_length_mm` on the x-axis.
-    Describe the relationship between these two variables.
+3.  Faça um gráfico de dispersão de `profundidade_bico` em função de `comprimento_bico`.
+    Ou seja, faça um gráfico de dispersão com `profundidade_bico` no eixo y e `comprimento_bico` no eixo x.
+    Descreva a relação entre essas duas variáveis.
 
-4.  What happens if you make a scatterplot of `species` vs. `bill_depth_mm`?
-    What might be a better choice of geom?
+4.  O que acontece se você fizer um gráfico de dispersão de `especie` em função de `profundidade_bico`?
+    Qual seria uma melhor escolha de geometria?
 
-5.  Why does the following give an error and how would you fix it?
+5.  Por que o seguinte erro ocorre e como você poderia corrigi-lo?
+
+```{r}
+#| eval: false
+
+ggplot(data = pinguins) + 
+  geom_point()
+```
+
+6.  O que o argumento `na.rm` faz em `geom_point()`?
+    Qual é o valor padrão do argumento?
+    Crie um gráfico de dispersão em que você use esse argumento definido como `TRUE` (verdadeiro).
+
+7.  Adicione a seguinte legenda ao gráfico que você criou no exercício anterior: "Os dados são provenientes do pacote dados".
+    Dica: dê uma olhada na documentação de `labs()`.
+
+8.  Recrie a visualização a seguir.
+    Para qual atributo estético `profundidade_bico` deve ser mapeada?
+    E ela deve ser mapeada no nível global ou no nível da geometria?
+
+```{r}
+#| echo: false
+#| warning: false
+#| fig-alt: |
+#|   A scatterplot of body mass vs. flipper length of pinguins, colored 
+#|   by bill depth. A smooth curve of the relationship between body mass 
+#|   and flipper length is overlaid. The relationship is positive, 
+#|   fairly linear, and moderately strong.
+
+ggplot(
+  data = pinguins,
+  mapping = aes(x = comprimento_nadadeira, y = massa_corporal)
+) +
+  geom_point(aes(color = profundidade_bico)) +
+  geom_smooth()
+```
+
+9.  Execute esse código em sua mente e preveja como será o resultado. Em seguida, execute o código no R e verifique suas previsões.
+
+```{r}
+#| eval: false
+
+ggplot(
+  data = pinguins,
+  mapping = aes(x = comprimento_nadadeira, y = massa_corporal, color = ilha)
+) +
+  geom_point() +
+  geom_smooth(se = FALSE)
+```
+
+10. Esses dois gráficos serão diferentes?
+    Por que sim ou por que não?
 
     ```{r}
     #| eval: false
 
-    ggplot(data = penguins) + 
-      geom_point()
-    ```
-
-6.  What does the `na.rm` argument do in `geom_point()`?
-    What is the default value of the argument?
-    Create a scatterplot where you successfully use this argument set to `TRUE`.
-
-7.  Add the following caption to the plot you made in the previous exercise: "Data come from the palmerpenguins package." Hint: Take a look at the documentation for `labs()`.
-
-8.  Recreate the following visualization.
-    What aesthetic should `bill_depth_mm` be mapped to?
-    And should it be mapped at the global level or at the geom level?
-
-    ```{r}
-    #| echo: false
-    #| warning: false
-    #| fig-alt: |
-    #|   A scatterplot of body mass vs. flipper length of penguins, colored 
-    #|   by bill depth. A smooth curve of the relationship between body mass 
-    #|   and flipper length is overlaid. The relationship is positive, 
-    #|   fairly linear, and moderately strong.
-
     ggplot(
-      data = penguins,
-      mapping = aes(x = flipper_length_mm, y = body_mass_g)
-    ) +
-      geom_point(aes(color = bill_depth_mm)) +
-      geom_smooth()
-    ```
-
-9.  Run this code in your head and predict what the output will look like.
-    Then, run the code in R and check your predictions.
-
-    ```{r}
-    #| eval: false
-
-    ggplot(
-      data = penguins,
-      mapping = aes(x = flipper_length_mm, y = body_mass_g, color = island)
-    ) +
-      geom_point() +
-      geom_smooth(se = FALSE)
-    ```
-
-10. Will these two graphs look different?
-    Why/why not?
-
-    ```{r}
-    #| eval: false
-
-    ggplot(
-      data = penguins,
-      mapping = aes(x = flipper_length_mm, y = body_mass_g)
+      datai = pinguins,
+      mapping = aes(x = comprimento_nadadeira, y = massa_corporal)
     ) +
       geom_point() +
       geom_smooth()
 
     ggplot() +
       geom_point(
-        data = penguins,
-        mapping = aes(x = flipper_length_mm, y = body_mass_g)
+        data = pinguins,
+        mapping = aes(x = comprimento_nadadeira, y = massa_corporal)
       ) +
       geom_smooth(
-        data = penguins,
-        mapping = aes(x = flipper_length_mm, y = body_mass_g)
+        data = pinguins,
+        mapping = aes(x = comprimento_nadadeira, y = massa_corporal)
       )
     ```
 
-## ggplot2 calls {#sec-ggplot2-calls}
+## Chamadas ggplot2 {#sec-ggplot2-calls}
 
-As we move on from these introductory sections, we'll transition to a more concise expression of ggplot2 code.
-So far we've been very explicit, which is helpful when you are learning:
+À medida que passarmos dessas seções introdutórias, faremos a transição para uma expressão mais concisa do código do ggplot2.
+Até agora, temos sido muito explícitos, o que é útil quando se está aprendendo:
 
 ```{r}
 #| eval: false
 
 ggplot(
-  data = penguins,
-  mapping = aes(x = flipper_length_mm, y = body_mass_g)
+  data = pinguins,
+  mapping = aes(x = comprimento_nadadeira, y = massa_corporal)
 ) +
   geom_point()
 ```
 
-Typically, the first one or two arguments to a function are so important that you should know them by heart.
-The first two arguments to `ggplot()` are `data` and `mapping`, in the remainder of the book, we won't supply those names.
-That saves typing, and, by reducing the amount of extra text, makes it easier to see what's different between plots.
-That's a really important programming concern that we'll come back to in @sec-functions.
+Normalmente, o primeiro ou os dois primeiros argumentos de uma função são tão importantes que você deve sabê-los de cor.
+Os dois primeiros argumentos de `ggplot()` são `data` e `mapping`; no restante do livro, não forneceremos esses nomes.
+Isso economiza digitação e, ao reduzir a quantidade de texto extra, facilita a visualização das diferenças entre os gráficos.
+Essa é uma preocupação de programação realmente importante, à qual voltaremos em @sec-functions.
 
-Rewriting the previous plot more concisely yields:
-
-```{r}
-#| eval: false
-
-ggplot(penguins, aes(x = flipper_length_mm, y = body_mass_g)) + 
-  geom_point()
-```
-
-In the future, you'll also learn about the pipe, `|>`, which will allow you to create that plot with:
+Reescrevendo o gráfico anterior de forma mais concisa, temos:
 
 ```{r}
 #| eval: false
 
-penguins |> 
-  ggplot(aes(x = flipper_length_mm, y = body_mass_g)) + 
+ggplot(pinguins, aes(x = comprimento_nadadeira, y = massa_corporal)) +
   geom_point()
 ```
 
-## Visualizing distributions
+No futuro, você também aprenderá sobre o pipe, `|>`, que permitirá que você crie esse gráfico com:
 
-How you visualize the distribution of a variable depends on the type of variable: categorical or numerical.
+```{r}
+#| eval: false
 
-### A categorical variable
+pinguins |> 
+  ggplot(aes(x = comprimento_nadadeira, y = massa_corporal)) + 
+  geom_point()
+```
 
-A variable is **categorical** if it can only take one of a small set of values.
-To examine the distribution of a categorical variable, you can use a bar chart.
-The height of the bars displays how many observations occurred with each `x` value.
+## Visualizando distribuições
+
+A forma como você visualiza a distribuição de uma variável depende do tipo de variável: categórica ou numérica.
+
+### Uma variável categórica
+
+Uma variável é **categórica** se puder assumir apenas um valor de um pequeno conjunto de valores.
+Para examinar a distribuição de uma variável categórica, você pode usar um gráfico de barras.
+A altura das barras exibe quantas observações ocorreram com cada valor `x`.
 
 ```{r}
 #| fig-alt: |
-#|   A bar chart of frequencies of species of penguins: Adelie 
+#|   A bar chart of frequencies of especie of pinguins: Adelie 
 #|   (approximately 150), Chinstrap (approximately 90), Gentoo 
 #|   (approximately 125).
 
-ggplot(penguins, aes(x = species)) +
+ggplot(pinguins, aes(x = especie)) +
   geom_bar()
 ```
 
-In bar plots of categorical variables with non-ordered levels, like the penguin `species` above, it's often preferable to reorder the bars based on their frequencies.
-Doing so requires transforming the variable to a factor (how R handles categorical data) and then reordering the levels of that factor.
+Em gráficos de barras de variáveis categóricas com níveis não ordenados, como a `especie` de pinguim acima, geralmente é preferível reordenar as barras com base em suas frequências.
+Para isso, é necessário transformar a variável em um fator (como o R lida com dados categóricos) e, em seguida, reordenar os níveis desse fator.
 
 ```{r}
 #| fig-alt: |
-#|   A bar chart of frequencies of species of penguins, where the bars are 
+#|   A bar chart of frequencies of especie of pinguins, where the bars are 
 #|   ordered in decreasing order of their heights (frequencies): Adelie 
 #|   (approximately 150), Gentoo (approximately 125), Chinstrap 
 #|   (approximately 90).
 
-ggplot(penguins, aes(x = fct_infreq(species))) +
+ggplot(pinguins, aes(x = fct_infreq(especie))) +
   geom_bar()
 ```
 
-You will learn more about factors and functions for dealing with factors (like `fct_infreq()` shown above) in @sec-factors.
+Você aprenderá mais sobre fatores e funções para lidar com fatores (como `fct_infreq()` mostrado acima) em @sec-factors.
 
-### A numerical variable
+### Uma variável numérica
 
-A variable is **numerical** (or quantitative) if it can take on a wide range of numerical values, and it is sensible to add, subtract, or take averages with those values.
-Numerical variables can be continuous or discrete.
+Uma variável é **numérica** (ou quantitativa) se puder assumir uma ampla gama de valores numéricos e se for possível adicionar, subtrair ou calcular médias com esses valores.
+As variáveis numéricas podem ser contínuas ou discretas.
 
-One commonly used visualization for distributions of continuous variables is a histogram.
+Uma visualização comumente usada para distribuições de variáveis contínuas é um histograma.
 
 ```{r}
 #| warning: false
 #| fig-alt: |
-#|   A histogram of body masses of penguins. The distribution is unimodal 
+#|   A histogram of body masses of pinguins. The distribution is unimodal 
 #|   and right skewed, ranging between approximately 2500 to 6500 grams.
 
-ggplot(penguins, aes(x = body_mass_g)) +
+ggplot(pinguins, aes(x = massa_corporal)) +
   geom_histogram(binwidth = 200)
 ```
 
-A histogram divides the x-axis into equally spaced bins and then uses the height of a bar to display the number of observations that fall in each bin.
-In the graph above, the tallest bar shows that 39 observations have a `body_mass_g` value between 3,500 and 3,700 grams, which are the left and right edges of the bar.
+Um histograma divide o eixo x em intervalos igualmente espaçados e, em seguida, usa a altura de uma barra para exibir o número de observações que se enquadram em cada intervalo.
+No gráfico acima, a barra mais alta mostra que 39 observações têm um valor `massa_corporal` entre 3500 e 3700 gramas, que são as bordas esquerda e direita da barra.
 
-You can set the width of the intervals in a histogram with the binwidth argument, which is measured in the units of the `x` variable.
-You should always explore a variety of binwidths when working with histograms, as different binwidths can reveal different patterns.
-In the plots below a binwidth of 20 is too narrow, resulting in too many bars, making it difficult to determine the shape of the distribution.
-Similarly, a binwidth of 2,000 is too high, resulting in all data being binned into only three bars, and also making it difficult to determine the shape of the distribution.
-A binwidth of 200 provides a sensible balance.
+Você pode definir a largura dos intervalos em um histograma com o argumento *binwidth* (largura do intervalo), que é medido nas unidades da variável `x`.
+Você deve sempre explorar uma variedade de larguras de intervalos ao trabalhar com histogramas, pois diferentes larguras de intervalos podem revelar padrões diferentes.
+Nos gráficos abaixo, uma largura de intervalo de 20 é muito estreita, resultando em muitas barras, o que dificulta a determinação da forma da distribuição.
+Da mesma forma, uma largura de intervalo de 2000 é muito alta, resultando em todos os dados sendo agrupados em apenas três barras, o que também dificulta a determinação da forma da distribuição.
+Uma largura de intervalo de 200 proporciona um balanço adequado.
 
 ```{r}
 #| warning: false
 #| layout-ncol: 2
 #| fig-width: 3
 #| fig-alt: |
-#|   Two histograms of body masses of penguins, one with binwidth of 20 
+#|   Two histograms of body masses of pinguins, one with binwidth of 20 
 #|   (left) and one with binwidth of 2000 (right). The histogram with binwidth 
 #|   of 20 shows lots of ups and downs in the heights of the bins, creating a 
 #|   jagged outline. The histogram  with binwidth of 2000 shows only three bins.
 
-ggplot(penguins, aes(x = body_mass_g)) +
+ggplot(pinguins, aes(x = massa_corporal)) +
   geom_histogram(binwidth = 20)
-ggplot(penguins, aes(x = body_mass_g)) +
+ggplot(pinguins, aes(x = massa_corporal)) +
   geom_histogram(binwidth = 2000)
 ```
 
-An alternative visualization for distributions of numerical variables is a density plot.
-A density plot is a smoothed-out version of a histogram and a practical alternative, particularly for continuous data that comes from an underlying smooth distribution.
-We won't go into how `geom_density()` estimates the density (you can read more about that in the function documentation), but let's explain how the density curve is drawn with an analogy.
-Imagine a histogram made out of wooden blocks.
-Then, imagine that you drop a cooked spaghetti string over it.
-The shape the spaghetti will take draped over blocks can be thought of as the shape of the density curve.
-It shows fewer details than a histogram but can make it easier to quickly glean the shape of the distribution, particularly with respect to modes and skewness.
+Uma visualização alternativa para distribuições de variáveis numéricas é um gráfico de densidade.
+Um gráfico de densidade é uma versão suavizada de um histograma e uma alternativa prática, especialmente para dados contínuos provenientes de uma distribuição suavizada subjacente.
+Não entraremos em detalhes sobre como `geom_density()` estima a densidade (você pode ler mais sobre isso na documentação da função), mas vamos explicar como a curva de densidade é desenhada com uma analogia.
+Imagine um histograma feito de blocos de madeira.
+Em seguida, imagine que você jogue um fio de espaguete cozido sobre ele.
+A forma que o espaguete assumirá sobre os blocos pode ser considerada como a forma da curva de densidade.
+Ela mostra menos detalhes do que um histograma, mas pode facilitar a obtenção rápida da forma da distribuição, principalmente com relação aos modos e à assimetria.
 
 ```{r}
 #| fig-alt: |
-#|   A density plot of body masses of penguins. The distribution is unimodal 
+#|   A density plot of body masses of pinguins. The distribution is unimodal 
 #|   and right skewed, ranging between approximately 2500 to 6500 grams.
 
-ggplot(penguins, aes(x = body_mass_g)) +
+ggplot(pinguins, aes(x = massa_corporal)) +
   geom_density()
 ```
 
-### Exercises
+### Exercícios
 
-1.  Make a bar plot of `species` of `penguins`, where you assign `species` to the `y` aesthetic.
-    How is this plot different?
+1.  Faça um gráfico de barras de `especie` de `pinguins`, no qual você atribui `especie` ao atributo estético `y`.
+    Como esse gráfico é diferente?
 
-2.  How are the following two plots different?
-    Which aesthetic, `color` or `fill`, is more useful for changing the color of bars?
+2.  Como os dois gráficos a seguir são diferentes?
+    Qual atributo estético, `color` ou `fill`, é mais útil para alterar a cor das barras?
 
-    ```{r}
-    #| eval: false
+```{r}
+#| eval: false
 
-    ggplot(penguins, aes(x = species)) +
-      geom_bar(color = "red")
+ggplot(pinguins, aes(x = especie)) +
+  geom_bar(color = "red")
 
-    ggplot(penguins, aes(x = species)) +
-      geom_bar(fill = "red")
-    ```
+ggplot(pinguins, aes(x = especie)) +
+  geom_bar(fill = "red")
+```
 
-3.  What does the `bins` argument in `geom_histogram()` do?
+3.  O que o argumento `bins` em `geom_histogram()` faz?
 
-4.  Make a histogram of the `carat` variable in the `diamonds` dataset that is available when you load the tidyverse package.
-    Experiment with different binwidths.
-    What binwidth reveals the most interesting patterns?
+4.  Faça um histograma da variável `quilate` no conjunto de dados `diamante` que está disponível quando você carrega o pacote dados.
+    Faça experiências com diferentes larguras de intervalo (*binwidth*).
+    Qual largura de intervalo revela os padrões mais interessantes?
 
-## Visualizing relationships
+## Visualizando relações
 
-To visualize a relationship we need to have at least two variables mapped to aesthetics of a plot.
-In the following sections you will learn about commonly used plots for visualizing relationships between two or more variables and the geoms used for creating them.
+Para visualizar uma relação, precisamos ter pelo menos duas variáveis mapeadas para os atributos estéticos de um gráfico.
+Nas seções a seguir, você aprenderá sobre os gráficos comumente usados para visualizar relações entre duas ou mais variáveis e os geoms usados para criá-los.
 
-### A numerical and a categorical variable
+### Uma variável numérica e uma variável categórica
 
-To visualize the relationship between a numerical and a categorical variable we can use side-by-side box plots.
-A **boxplot** is a type of visual shorthand for measures of position (percentiles) that describe a distribution.
-It is also useful for identifying potential outliers.
-As shown in @fig-eda-boxplot, each boxplot consists of:
+Para visualizar a relação entre uma variável numérica e uma variável categórica, podemos usar diagramas de caixa (chamados ***boxplots***) lado a lado.
+Um **boxplot** é um tipo de abreviação visual para medidas de posição (percentis) que descrevem uma distribuição.
+Também é útil para identificar possíveis *outliers*.
+Conforme mostrado em @fig-eda-boxplot, cada boxplot consiste em:
 
--   A box that indicates the range of the middle half of the data, a distance known as the interquartile range (IQR), stretching from the 25th percentile of the distribution to the 75th percentile.
-    In the middle of the box is a line that displays the median, i.e. 50th percentile, of the distribution.
-    These three lines give you a sense of the spread of the distribution and whether or not the distribution is symmetric about the median or skewed to one side.
+-   Uma caixa que indica o intervalo da metade intermediária dos dados, uma distância conhecida como intervalo interquartil (IIQ), que se estende do 25º percentil da distribuição até o 75º percentil.
+    No meio da caixa há uma linha que exibe a mediana, ou seja, o 50º percentil, da distribuição.
+    Essas três linhas lhe dão uma noção da dispersão da distribuição e se a distribuição é ou não simétrica em relação à mediana ou inclinada para um lado.
 
--   Visual points that display observations that fall more than 1.5 times the IQR from either edge of the box.
-    These outlying points are unusual so are plotted individually.
+-   Pontos que apresentam observações com valores maiores que 1,5 vezes o IIQ de qualquer borda da caixa.
+    Esses pontos discrepantes são incomuns e, por isso, são plotados individualmente.
 
--   A line (or whisker) that extends from each end of the box and goes to the farthest non-outlier point in the distribution.
+-   Uma linha que se estende de cada extremidade da caixa e vai até o ponto mais distante sem *outlier* na distribuição.
 
 ```{r}
 #| label: fig-eda-boxplot
@@ -642,211 +642,209 @@ As shown in @fig-eda-boxplot, each boxplot consists of:
 knitr::include_graphics("images/EDA-boxplot.png")
 ```
 
-Let's take a look at the distribution of body mass by species using `geom_boxplot()`:
+Vamos dar uma olhada na distribuição da massa corporal por espécie usando `geom_boxplot()`:
 
 ```{r}
 #| warning: false
 #| fig-alt: |
 #|   Side-by-side box plots of distributions of body masses of Adelie, 
-#|   Chinstrap, and Gentoo penguins. The distribution of Adelie and 
-#|   Chinstrap penguins' body masses appear to be symmetric with 
-#|   medians around 3750 grams. The median body mass of Gentoo penguins 
+#|   Chinstrap, and Gentoo pinguins. The distribution of Adelie and 
+#|   Chinstrap pinguins' body masses appear to be symmetric with 
+#|   medians around 3750 grams. The median body mass of Gentoo pinguins 
 #|   is much higher, around 5000 grams, and the distribution of the 
-#|   body masses of these penguins appears to be somewhat right skewed.
+#|   body masses of these pinguins appears to be somewhat right skewed.
 
-ggplot(penguins, aes(x = species, y = body_mass_g)) +
+ggplot(pinguins, aes(x = especie, y = massa_corporal)) +
   geom_boxplot()
 ```
 
-Alternatively, we can make density plots with `geom_density()`.
+Como alternativa, podemos criar gráficos de densidade com `geom_density()`.
 
 ```{r}
 #| warning: false
 #| fig-alt: |
-#|   A density plot of body masses of penguins by species of penguins. Each 
-#|   species (Adelie, Chinstrap, and Gentoo) is represented with different 
+#|   A density plot of body masses of pinguins by especie of pinguins. Each 
+#|   especie (Adelie, Chinstrap, and Gentoo) is represented with different 
 #|   colored outlines for the density curves.
 
-ggplot(penguins, aes(x = body_mass_g, color = species)) +
+ggplot(pinguins, aes(x = massa_corporal, color = especie)) +
   geom_density(linewidth = 0.75)
 ```
 
-We've also customized the thickness of the lines using the `linewidth` argument in order to make them stand out a bit more against the background.
+Também personalizamos a espessura das linhas usando o argumento `linewidth` para que elas se destaquem um pouco mais contra o plano de fundo.
 
-Additionally, we can map `species` to both `color` and `fill` aesthetics and use the `alpha` aesthetic to add transparency to the filled density curves.
-This aesthetic takes values between 0 (completely transparent) and 1 (completely opaque).
-In the following plot it's *set* to 0.5.
+Além disso, podemos mapear `especie` para os atributos estéticos `color` e `fill` e usar o atributo `alpha` para adicionar transparência às curvas de densidade preenchidas.
+Esse atributo assume valores entre 0 (completamente transparente) e 1 (completamente opaco).
+No gráfico a seguir, ela está *definida* como 0,5.
 
 ```{r}
 #| warning: false
 #| fig-alt: |
-#|   A density plot of body masses of penguins by species of penguins. Each 
-#|   species (Adelie, Chinstrap, and Gentoo) is represented in different 
+#|   A density plot of body masses of pinguins by especie of pinguins. Each 
+#|   especie (Adelie, Chinstrap, and Gentoo) is represented in different 
 #|   colored outlines for the density curves. The density curves are also 
 #|   filled with the same colors, with some transparency added.
 
-ggplot(penguins, aes(x = body_mass_g, color = species, fill = species)) +
+ggplot(pinguins, aes(x = massa_corporal, color = especie, fill = especie)) +
   geom_density(alpha = 0.5)
 ```
 
-Note the terminology we have used here:
+Observe a terminologia que usamos aqui:
 
--   We *map* variables to aesthetics if we want the visual attribute represented by that aesthetic to vary based on the values of that variable.
--   Otherwise, we *set* the value of an aesthetic.
+-   Nós *mapeamos* variáveis para atributos estéticos se quisermos que o atributo visual representado por esse atributo varie com base nos valores dessa variável.
+-   Caso contrário, nós *definimos* o valor de um atributo estético.
 
-### Two categorical variables
+### Duas variáveis categóricas
 
-We can use stacked bar plots to visualize the relationship between two categorical variables.
-For example, the following two stacked bar plots both display the relationship between `island` and `species`, or specifically, visualizing the distribution of `species` within each island.
+Podemos usar gráficos de barras empilhadas para visualizar a relação entre duas variáveis categóricas.
+Por exemplo, os dois gráficos de barras empilhadas a seguir exibem a relação entre `ilha` e `espécie` ou, especificamente, a visualização da distribuição de `espécie` em cada ilha.
 
-The first plot shows the frequencies of each species of penguins on each island.
-The plot of frequencies show that there are equal numbers of Adelies on each island.
-But we don't have a good sense of the percentage balance within each island.
+O primeiro gráfico mostra as frequências de cada espécie de pinguim em cada ilha.
+O gráfico de frequências mostra que há um número igual de Pinguim-de-adélia em cada ilha.
+Mas não temos uma boa noção do equilíbrio percentual em cada ilha.
 
 ```{r}
 #| fig-alt: |
-#|   Bar plots of penguin species by island (Biscoe, Dream, and Torgersen)
-ggplot(penguins, aes(x = island, fill = species)) +
+#|   Bar plots of penguin especie by ilha (Biscoe, Dream, and Torgersen)
+ggplot(pinguins, aes(x = ilha, fill = especie)) +
   geom_bar()
 ```
 
-The second plot is a relative frequency plot, created by setting `position = "fill"` in the geom is more useful for comparing species distributions across islands since it's not affected by the unequal numbers of penguins across the islands.
-Using this plot we can see that Gentoo penguins all live on Biscoe island and make up roughly 75% of the penguins on that island, Chinstrap all live on Dream island and make up roughly 50% of the penguins on that island, and Adelie live on all three islands and make up all of the penguins on Torgersen.
+O segundo gráfico é um gráfico de frequência relativa, criado pela definição de `position = "fill"` na geom, que é mais útil para comparar as distribuições de espécies entre as ilhas, pois não é afetado pelo número desigual de pinguins entre as ilhas.
+Usando esse gráfico, podemos ver que todos os Pinguim-gentoo vivem na ilha Biscoe e constituem aproximadamente 75% dos pinguins dessa ilha, todos os Pinguim-de-barbicha vivem na ilha Dream e constituem aproximadamente 50% dos pinguins dessa ilha, e os Pinguim-de-adélia vivem nas três ilhas e constituem todos os pinguins de Torgersen.
 
 ```{r}
 #| fig-alt: |
-#|   Bar plots of penguin species by island (Biscoe, Dream, and Torgersen)
+#|   Bar plots of penguin especie by ilha (Biscoe, Dream, and Torgersen)
 #|   the bars are scaled to the same height, making it a relative frequencies 
 #|   plot
 
-ggplot(penguins, aes(x = island, fill = species)) +
+ggplot(pinguins, aes(x = ilha, fill = especie)) +
   geom_bar(position = "fill")
 ```
 
-In creating these bar charts, we map the variable that will be separated into bars to the `x` aesthetic, and the variable that will change the colors inside the bars to the `fill` aesthetic.
+Ao criar esses gráficos de barras, mapeamos a variável que será separada em barras para o atributo estético `x` e a variável que mudará as cores dentro das barras para a estética `fill`.
 
-### Two numerical variables
+### Duas variáveis numéricas
 
-So far you've learned about scatterplots (created with `geom_point()`) and smooth curves (created with `geom_smooth()`) for visualizing the relationship between two numerical variables.
-A scatterplot is probably the most commonly used plot for visualizing the relationship between two numerical variables.
+Até agora, você aprendeu sobre gráficos de dispersão (criados com `geom_point()`) e curvas suaves (criadas com `geom_smooth()`) para visualizar a relação entre duas variáveis numéricas.
+Um gráfico de dispersão é provavelmente o gráfico mais usado para visualizar a relação entre duas variáveis numéricas.
 
 ```{r}
 #| warning: false
 #| fig-alt: |
-#|   A scatterplot of body mass vs. flipper length of penguins. The plot 
+#|   A scatterplot of body mass vs. flipper length of pinguins. The plot 
 #|   displays a positive, linear, relatively strong relationship between 
 #|   these two variables.
 
-ggplot(penguins, aes(x = flipper_length_mm, y = body_mass_g)) +
+ggplot(pinguins, aes(x = comprimento_nadadeira, y = massa_corporal)) +
   geom_point()
 ```
 
-### Three or more variables
+### Três ou mais variáveis
 
-As we saw in @sec-adding-aesthetics-layers, we can incorporate more variables into a plot by mapping them to additional aesthetics.
-For example, in the following scatterplot the colors of points represent species and the shapes of points represent islands.
+Como vimos em @sec-adding-aesthetics-layers, podemos incorporar mais variáveis em um gráfico mapeando-as para atributos estéticos adicionais.
+Por exemplo, no gráfico de dispersão a seguir, as cores dos pontos (*color*) representam espécies e as formas dos pontos (*shape*) representam ilhas.
 
 ```{r}
 #| warning: false
 #| fig-alt: |
-#|   A scatterplot of body mass vs. flipper length of penguins. The plot 
+#|   A scatterplot of body mass vs. flipper length of pinguins. The plot 
 #|   displays a positive, linear, relatively strong relationship between 
-#|   these two variables. The points are colored based on the species of the 
-#|   penguins and the shapes of the points represent islands (round points are 
-#|   Biscoe island, triangles are Dream island, and squared are Torgersen 
-#|   island). The plot is very busy and it's difficult to distinguish the shapes
+#|   these two variables. The points are colored based on the especie of the 
+#|   pinguins and the shapes of the points represent ilhas (round points are 
+#|   Biscoe ilha, triangles are Dream ilha, and squared are Torgersen 
+#|   ilha). The plot is very busy and it's difficult to distinguish the shapes
 #|   of the points.
 
-ggplot(penguins, aes(x = flipper_length_mm, y = body_mass_g)) +
-  geom_point(aes(color = species, shape = island))
+ggplot(pinguins, aes(x = comprimento_nadadeira, y = massa_corporal)) +
+  geom_point(aes(color = especie, shape = ilha))
 ```
 
-However adding too many aesthetic mappings to a plot makes it cluttered and difficult to make sense of.
-Another way, which is particularly useful for categorical variables, is to split your plot into **facets**, subplots that each display one subset of the data.
+No entanto, mapear muitos atirbutos estéticos a um gráfico faz com que ele fique desordenado e difícil de entender.
+Outra maneira, que é particularmente útil para variáveis categóricas, é dividir seu gráfico em **facetas**, subdivisões que exibem um subconjunto dos dados cada uma.
 
-To facet your plot by a single variable, use `facet_wrap()`.
-The first argument of `facet_wrap()` is a formula[^data-visualize-3], which you create with `~` followed by a variable name.
-The variable that you pass to `facet_wrap()` should be categorical.
+Para separar seu gráfico em facetas por uma única variável, use `facet_wrap()`.
+O primeiro argumento de `facet_wrap()` é uma fórmula[^data-visualize-3], que você cria com `~` seguido do nome de uma variável.
+A variável que você passa para `facet_wrap()` deve ser categórica.
 
-[^data-visualize-3]: Here "formula" is the name of the thing created by `~`, not a synonym for "equation".
+[^data-visualize-3]: Aqui "fórmula" é o nome da coisa criada por `~`, não um sinônimo de "equação".
 
 ```{r}
 #| warning: false
 #| fig-width: 8
 #| fig-asp: 0.33
 #| fig-alt: |
-#|   A scatterplot of body mass vs. flipper length of penguins. The shapes and 
-#|   colors of points represent species. Penguins from each island are on a 
+#|   A scatterplot of body mass vs. flipper length of pinguins. The shapes and 
+#|   colors of points represent especie. pinguins from each ilha are on a 
 #|   separate facet. Within each facet, the relationship between body mass and 
 #|   flipper length is positive, linear, relatively strong. 
 
-ggplot(penguins, aes(x = flipper_length_mm, y = body_mass_g)) +
-  geom_point(aes(color = species, shape = species)) +
-  facet_wrap(~island)
+ggplot(pinguins, aes(x = comprimento_nadadeira, y = massa_corporal)) +
+  geom_point(aes(color = especie, shape = especie)) +
+  facet_wrap(~ilha)
 ```
 
-You will learn about many other geoms for visualizing distributions of variables and relationships between them in @sec-layers.
+Você vai aprender sobre muitas outras geometrias para visualizar distribuições de variáveis e relações entre elas em @sec-layers.
 
-### Exercises
+### Exercícios
 
-1.  The `mpg` data frame that is bundled with the ggplot2 package contains `r nrow(mpg)` observations collected by the US Environmental Protection Agency on `r mpg |> distinct(model) |> nrow()` car models.
-    Which variables in `mpg` are categorical?
-    Which variables are numerical?
-    (Hint: Type `?mpg` to read the documentation for the dataset.) How can you see this information when you run `mpg`?
+1.  O *data frame* `milhas` que acompanha o pacote dados contém observações `r nrow(milhas)` coletadas pela Agência de Proteção Ambiental dos EUA em modelos de `r milhas |> distinct(modelo) |> nrow()` carros.
+    Quais variáveis em `milhas` são categóricas?
+    Quais variáveis são numéricas?
+    (Dica: digite `?milhas` para ler a documentação do conjunto de dados.) Como você pode ver essas informações ao executar `milhas`?
 
-2.  Make a scatterplot of `hwy` vs. `displ` using the `mpg` data frame.
-    Next, map a third, numerical variable to `color`, then `size`, then both `color` and `size`, then `shape`.
-    How do these aesthetics behave differently for categorical vs. numerical variables?
+2.  Faça um gráfico de dispersão de `rodovia` (Milhas rodoviárias por galão) em função de `cilindrada` usando o *data frame* `milhas`.
+    Em seguida, mapeie uma terceira variável numérica para `color` (cor), depois `size` (tamanho), depois igualmente para `color` e `size` e, por fim, `shape` (forma).
+    Como esses atributos estéticos se comportam de forma diferente para variáveis categóricas e numéricas?
 
-3.  In the scatterplot of `hwy` vs. `displ`, what happens if you map a third variable to `linewidth`?
+3.  No gráfico de dispersão de `rodovia` vs. `cilindrada`, o que acontece se você mapear uma terceira variável para `linewidth` (espessura da linha)?
 
-4.  What happens if you map the same variable to multiple aesthetics?
+4.  O que acontece se você mapear a mesma variável para várias atributos estéticos?
 
-5.  Make a scatterplot of `bill_depth_mm` vs. `bill_length_mm` and color the points by `species`.
-    What does adding coloring by species reveal about the relationship between these two variables?
-    What about faceting by `species`?
+5.  Faça um gráfico de dispersão de `profundidade_bico` vs. `comprimento_bico` e pinte os pontos por `especie`.
+    O que a adição da coloração por especie revela sobre a relação entre essas duas variáveis?
+    E quanto à separação em facetas por `especie`?
 
-6.  Why does the following yield two separate legends?
-    How would you fix it to combine the two legends?
+6.  Por que o seguinte código produz duas legendas separadas?
+    Como você corrigiria isso para combinar as duas legendas?
 
-    ```{r}
-    #| warning: false
-    #| fig-show: hide
+```{r}
+#| warning: false
+#| fig-show: hide
 
-    ggplot(
-      data = penguins,
-      mapping = aes(
-        x = bill_length_mm, y = bill_depth_mm, 
-        color = species, shape = species
-      )
-    ) +
-      geom_point() +
-      labs(color = "Species")
-    ```
+ggplot(
+  data = pinguins,
+  mapping = aes(
+    x = comprimento_bico, y = profundidade_bico, 
+    color = especie, shape = especie
+  )
+) +
+  geom_point() +
+  labs(color = "especie")
+```
 
-7.  Create the two following stacked bar plots.
-    Which question can you answer with the first one?
-    Which question can you answer with the second one?
+7.  Crie os dois gráficos de barras empilhadas a seguir. Que pergunta você pode responder com o primeiro? Que pergunta você pode responder com o segundo?
 
-    ```{r}
-    #| fig-show: hide
+```{r}
+#| fig-show: hide
 
-    ggplot(penguins, aes(x = island, fill = species)) +
-      geom_bar(position = "fill")
-    ggplot(penguins, aes(x = species, fill = island)) +
-      geom_bar(position = "fill")
-    ```
+ggplot(pinguins, aes(x = ilha, fill = especie)) +
+  geom_bar(position = "fill")
+ggplot(pinguins, aes(x = especie, fill = ilha)) +
+  geom_bar(position = "fill")
+```
 
-## Saving your plots {#sec-ggsave}
+## Salvando seus gráficos {#sec-ggsave}
 
-Once you've made a plot, you might want to get it out of R by saving it as an image that you can use elsewhere.
-That's the job of `ggsave()`, which will save the plot most recently created to disk:
+Depois de criar um gráfico, talvez você queira tirá-lo do R salvando-o como uma imagem que possa ser usada em outro lugar.
+Essa é a função de `ggsave()`, que salvará no computador o gráfico criado mais recentemente:
 
 ```{r}
 #| fig-show: hide
 #| warning: false
 
-ggplot(penguins, aes(x = flipper_length_mm, y = body_mass_g)) +
+ggplot(pinguins, aes(x = comprimento_nadadeira, y = massa_corporal)) +
   geom_point()
 ggsave(filename = "penguin-plot.png")
 ```
@@ -857,74 +855,71 @@ ggsave(filename = "penguin-plot.png")
 file.remove("penguin-plot.png")
 ```
 
-This will save your plot to your working directory, a concept you'll learn more about in @sec-workflow-scripts-projects.
+Isso salvará o gráfico no seu diretório de trabalho, um conceito sobre o qual você aprenderá mais em @sec-workflow-scripts-projects.
 
-If you don't specify the `width` and `height` they will be taken from the dimensions of the current plotting device.
-For reproducible code, you'll want to specify them.
-You can learn more about `ggsave()` in the documentation.
+Se você não especificar a largura `width` e a altura `height`, elas serão tiradas das dimensões do dispositivo de plotagem atual.
+Para obter um código reprodutível, você deverá especificá-los.
+Você pode obter mais informações sobre `ggsave()` na documentação.
 
-Generally, however, we recommend that you assemble your final reports using Quarto, a reproducible authoring system that allows you to interleave your code and your prose and automatically include your plots in your write-ups.
-You will learn more about Quarto in @sec-quarto.
+De modo geral, entretanto, recomendamos que você monte seus relatórios finais usando o Quarto, um sistema de autoria reproduzível que permite intercalar seu código e sua escrita e incluir automaticamente seus gráficos em seus relatórios.
+Você saberá mais sobre o Quarto em @sec-quarto.
 
-### Exercises
+### Exercícios
 
-1.  Run the following lines of code.
-    Which of the two plots is saved as `mpg-plot.png`?
-    Why?
-
-    ```{r}
-    #| eval: false
-
-    ggplot(mpg, aes(x = class)) +
-      geom_bar()
-    ggplot(mpg, aes(x = cty, y = hwy)) +
-      geom_point()
-    ggsave("mpg-plot.png")
-    ```
-
-2.  What do you need to change in the code above to save the plot as a PDF instead of a PNG?
-    How could you find out what types of image files would work in `ggsave()`?
-
-## Common problems
-
-As you start to run R code, you're likely to run into problems.
-Don't worry --- it happens to everyone.
-We have all been writing R code for years, but every day we still write code that doesn't work on the first try!
-
-Start by carefully comparing the code that you're running to the code in the book.
-R is extremely picky, and a misplaced character can make all the difference.
-Make sure that every `(` is matched with a `)` and every `"` is paired with another `"`.
-Sometimes you'll run the code and nothing happens.
-Check the left-hand of your console: if it's a `+`, it means that R doesn't think you've typed a complete expression and it's waiting for you to finish it.
-In this case, it's usually easy to start from scratch again by pressing ESCAPE to abort processing the current command.
-
-One common problem when creating ggplot2 graphics is to put the `+` in the wrong place: it has to come at the end of the line, not the start.
-In other words, make sure you haven't accidentally written code like this:
+1.  Execute as seguintes linhas de código. Qual dos dois gráficos é salvo como `grafico-milhas.png`? Por quê?
 
 ```{r}
 #| eval: false
 
-ggplot(data = mpg) 
-+ geom_point(mapping = aes(x = displ, y = hwy))
+ggplot(milhas, aes(x = classe)) +
+  geom_bar()
+ggplot(milhas, aes(x = cidade, y = rodovia)) +
+  geom_point()
+ggsave("grafico-milhas.png")
 ```
 
-If you're still stuck, try the help.
-You can get help about any R function by running `?function_name` in the console, or highlighting the function name and pressing F1 in RStudio.
-Don't worry if the help doesn't seem that helpful - instead skip down to the examples and look for code that matches what you're trying to do.
+2.  O que você precisa alterar no código acima para salvar o gráfico como PDF em vez de PNG? Como você poderia descobrir quais tipos de arquivos de imagem funcionariam em `ggsave()`?
 
-If that doesn't help, carefully read the error message.
-Sometimes the answer will be buried there!
-But when you're new to R, even if the answer is in the error message, you might not yet know how to understand it.
-Another great tool is Google: try googling the error message, as it's likely someone else has had the same problem, and has gotten help online.
+## Problemas comuns
 
-## Summary
+Ao começar a executar o código em R, é provável que você encontre problemas.
+Não se preocupe, isso acontece com todo mundo.
+Todos nós estamos escrevendo código em R há anos, mas todos os dias ainda escrevemos códigos que não funciona na primeira tentativa!
 
-In this chapter, you've learned the basics of data visualization with ggplot2.
-We started with the basic idea that underpins ggplot2: a visualization is a mapping from variables in your data to aesthetic properties like position, color, size and shape.
-You then learned about increasing the complexity and improving the presentation of your plots layer-by-layer.
-You also learned about commonly used plots for visualizing the distribution of a single variable as well as for visualizing relationships between two or more variables, by leveraging additional aesthetic mappings and/or splitting your plot into small multiples using faceting.
+Comece comparando cuidadosamente o código que está executando com o código do livro.
+O R é extremamente exigente, e um caractere mal colocado pode fazer toda a diferença.
+Certifique-se de que cada `(` seja combinado com um `)` e que cada `"` seja combinado com outra `"`.
+Às vezes, você executará o código e nada acontecerá.
+Verifique o lado esquerdo do console: se houver um `+`, isso significa que o R acha que você não digitou uma expressão completa e está esperando que você a termine.
+Nesse caso, geralmente é fácil começar do zero novamente pressionando *Esc* para interromper o processamento do comando atual.
 
-We'll use visualizations again and again throughout this book, introducing new techniques as we need them as well as do a deeper dive into creating visualizations with ggplot2 in @sec-layers through @sec-communication.
+Um problema comum ao criar gráficos ggplot2 é colocar o `+` no lugar errado: ele deve vir no final da linha, não no início.
+Em outras palavras, certifique-se de não ter escrito acidentalmente um código como este:
 
-With the basics of visualization under your belt, in the next chapter we're going to switch gears a little and give you some practical workflow advice.
-We intersperse workflow advice with data science tools throughout this part of the book because it'll help you stay organized as you write increasing amounts of R code.
+```{r}
+#| eval: false
+
+ggplot(data = milhas) 
++ geom_point(mapping = aes(x = cilindrada, y = rodovia))
+```
+
+Se você ainda estiver com dificuldades, tente a ajuda.
+Você pode obter ajuda sobre qualquer função do R executando `?nome_da_função` no console ou selecionando o nome da função e pressionando F1 no RStudio.
+Não se preocupe se a ajuda não parecer muito útil - em vez disso, pule para os exemplos e procure um código que corresponda ao que você está tentando fazer.
+
+Se isso não ajudar, leia atentamente a mensagem de erro.
+Às vezes, a resposta estará escondida lá!
+Mas quando você é novo no R, mesmo que a resposta esteja na mensagem de erro, talvez você ainda não saiba como entendê-la.
+Outra ferramenta excelente é o Google: tente pesquisar a mensagem de erro no Google, pois é provável que outra pessoa tenha tido o mesmo problema e tenha obtido ajuda on-line.
+
+## Resumo
+
+Neste capítulo, você aprendeu os fundamentos da visualização de dados com o ggplot2.
+Começamos com a ideia básica que sustenta o ggplot2: uma visualização é um mapeamento de variáveis em seus dados para atributos estéticos como posição (*position*), cor (*color*), tamanho (*size*) e forma (*shape*).
+Em seguida, você aprendeu a aumentar a complexidade e melhorar a apresentação de seus gráficos camada por camada.
+Você também aprendeu sobre gráficos comumente usados para visualizar a distribuição de uma única variável, bem como para visualizar relações entre duas ou mais variáveis ao utilizar mapeamentos de atributos estéticos adicionais e/ou dividindo seu gráfico em pequenos múltiplos usando facetas.
+
+Usaremos as visualizações repetidamente ao longo deste livro, introduzindo novas técnicas à medida que precisarmos delas, além de nos aprofundarmos na criação de visualizações com o ggplot2 em @sec-layers por meio da @sec-communication.
+
+Com as noções básicas de visualização em seu currículo, no próximo capítulo mudaremos um pouco a direção e daremos algumas orientações práticas sobre o fluxo de trabalho.
+Intercalamos conselhos sobre fluxo de trabalho com ferramentas de ciência de dados ao longo desta parte do livro, pois isso o ajudará a se manter organizado à medida que você escreve quantidades cada vez maiores de código em R.

--- a/data-visualize.qmd
+++ b/data-visualize.qmd
@@ -129,15 +129,14 @@ Nosso objetivo final neste capítulo é recriar a seguinte visualização que ex
 ```{r}
 #| echo: false
 #| warning: false
-#| fig-alt: |
-#|   A scatterplot of body mass vs. flipper length of pinguins, with a
-#|   best fit line of the relationship between these two variables 
-#|   overlaid. The plot displays a positive, fairly linear, and relatively 
-#|   strong relationship between these two variables. especie (Adelie, 
-#|   Chinstrap, and Gentoo) are represented with different colors and 
-#|   shapes. The relationship between body mass and flipper length is 
-#|   roughly the same for these three especie, and Gentoo pinguins are 
-#|   larger than pinguins from the other two especie.
+#|   Um gráfico de dispersão da massa corporal vs. comprimento da
+#|   nadadeira dos pinguins, com uma linha de melhor ajuste da relação
+#|   entre essas duas variáveis sobreposta. O gráfico mostra uma relação 
+#|   positiva, razoavelmente linear e relativamente forte entre essas 
+#|   duas variáveis. As espécies (Pinguim-de-adélia, Pinguim-de-barbicha 
+#|   e Pinguim-gentoo) são representadas com cores e formas diferentes. A #|   relação entre a massa corporal e o comprimento da nadadeira é 
+#|   aproximadamente a mesma para essas três espécies, e os pinguins 
+#|   Gentoo são maiores do que os pinguins das outras duas espécies.
 
 ggplot(pinguins, aes(x = comprimento_nadadeira, y = massa_corporal)) +
   geom_point(aes(color = especie, shape = especie)) +
@@ -178,9 +177,9 @@ O gráfico a seguir mostra o resultado da adição desses mapeamentos.
 
 ```{r}
 #| fig-alt: |
-#|   The plot shows flipper length on the x-axis, with values that range from 
-#|   170 to 230, and body mass on the y-axis, with values that range from 3000 
-#|   to 6000.
+#|   O gráfico mostra o comprimento da nadadeira no eixo x, com valores 
+#|   que variam de 170 a 230, e a massa corporal no eixo y, com valores 
+#|   que variam de 3000 a 6000.
 
 ggplot(
   data = pinguins,
@@ -203,9 +202,9 @@ Você aprenderá várias geometrias ao longo do livro, principalmente em @sec-la
 
 ```{r}
 #| fig-alt: |
-#|   A scatterplot of body mass vs. flipper length of pinguins. The plot 
-#|   displays a positive, linear, and relatively strong relationship between 
-#|   these two variables.
+#|   Um gráfico de dispersão da massa corporal em função do comprimento 
+#|   da nadadeira dos pinguins. O gráfico mostra uma relação positiva, 
+#|   linear e relativamente forte entre essas duas variáveis.
 
 ggplot(
   data = pinguins,
@@ -242,10 +241,11 @@ Ao longo do livro, você criará muito mais visualizações com ggplot e terá m
 ```{r}
 #| warning: false
 #| fig-alt: |
-#|   A scatterplot of body mass vs. flipper length of pinguins. The plot 
-#|   displays a positive, fairly linear, and relatively strong relationship 
-#|   between these two variables. especie (Adelie, Chinstrap, and Gentoo) 
-#|   are represented with different colors.
+#|   Um gráfico de dispersão da massa corporal em função do comprimento 
+#|   da nadadeira dos pinguins. O gráfico mostra uma relação positiva, 
+#|   razoavelmente linear e relativamente forte entre essas duas 
+#|   variáveis. As espécies (Pinguim-de-adélia, Pinguim-de-barbicha e 
+#|   Pinguim-gentoo) são representadas com cores diferentes.
 
 ggplot(
   data = pinguins,
@@ -266,11 +266,12 @@ E especificaremos que queremos desenhar a linha de melhor ajuste com base em um 
 ```{r}
 #| warning: false
 #| fig-alt: |
-#|   A scatterplot of body mass vs. flipper length of pinguins. Overlaid 
-#|   on the scatterplot are three smooth curves displaying the 
-#|   relationship between these variables for each especie (Adelie, 
-#|   Chinstrap, and Gentoo). Different penguin especie are plotted in 
-#|   different colors for the points and the smooth curves.
+#|   Um gráfico de dispersão da massa corporal em função o comprimento da
+#|   nadadeira dos pinguins. Sobrepostas ao gráfico de dispersão estão 
+#|   três curvas suavizadas que mostram a relação entre essas variáveis 
+#|   para cada espécie (Pinguim-de-adélia, Pinguim-de-barbicha e 
+#|   Pinguim-gentoo). As diferentes espécies de pinguins são plotadas em 
+#|   cores diferentes para os pontos e as curvas suavizadas.
 
 ggplot(
   data = pinguins,
@@ -289,11 +290,12 @@ Como queremos que os pontos sejam coloridos com base na espécie, mas não quere
 ```{r}
 #| warning: false
 #| fig-alt: |
-#|   A scatterplot of body mass vs. flipper length of pinguins. Overlaid 
-#|   on the scatterplot is a single line of best fit displaying the 
-#|   relationship between these variables for each especie (Adelie, 
-#|   Chinstrap, and Gentoo). Different penguin especie are plotted in 
-#|   different colors for the points only.
+#|   Um gráfico de dispersão da massa corporal em função o comprimento da
+#|   nadadeira dos pinguins. Sobreposta ao gráfico de dispersão está
+#|   uma única linha de melhor ajuste que mostra a relação entre essas 
+#|   variáveis para cada espécie (Pinguim-de-adélia, Pinguim-de-barbicha 
+#|   e Pinguim-gentoo). As diferentes espécies de pinguins são plotadas 
+#|   em cores diferentes somente para os pontos.
 
 ggplot(
   data = pinguins,
@@ -313,11 +315,12 @@ Portanto, além da cor, também podemos mapear `especie` para a estética `shape
 ```{r}
 #| warning: false
 #| fig-alt: |
-#|   A scatterplot of body mass vs. flipper length of pinguins. Overlaid 
-#|   on the scatterplot is a single line of best fit displaying the 
-#|   relationship between these variables for each especie (Adelie, 
-#|   Chinstrap, and Gentoo). Different penguin especie are plotted in 
-#|   different colors and shapes for the points only.
+#|   Um gráfico de dispersão da massa corporal em função o comprimento da
+#|   nadadeira dos pinguins. Sobreposta ao gráfico de dispersão está
+#|   uma única linha de melhor ajuste que mostra a relação entre essas 
+#|   variáveis para cada espécie (Pinguim-de-adélia, Pinguim-de-barbicha 
+#|   e Pinguim-gentoo). As diferentes espécies de pinguins são plotadas 
+#|   em cores e formas diferentes somente para os pontos.
 
 ggplot(
   data = pinguins,
@@ -337,14 +340,16 @@ Além disso, podemos aprimorar a paleta de cores para que seja segura para pesso
 ```{r}
 #| warning: false
 #| fig-alt: |
-#|   A scatterplot of body mass vs. flipper length of pinguins, with a 
-#|   line of best fit displaying the relationship between these two variables 
-#|   overlaid. The plot displays a positive, fairly linear, and relatively 
-#|   strong relationship between these two variables. especie (Adelie, 
-#|   Chinstrap, and Gentoo) are represented with different colors and 
-#|   shapes. The relationship between body mass and flipper length is 
-#|   roughly the same for these three especie, and Gentoo pinguins are 
-#|   larger than pinguins from the other two especie.
+#|   Um gráfico de dispersão da massa corporal em função do comprimento 
+#|   da nadadeira dos pinguins, junto de uma linha de melhor ajuste 
+#|   sobreposta que mostra a relação entre essas duas variáveis. O 
+#|   gráfico mostra uma relação positiva, razoavelmente linear e 
+#|   relativamente forte entre essas duas variáveis. As espécies 
+#|   (Pinguim-de-adélia,  Pinguim-de-barbicha e Pinguim-gentoo) são 
+#|   representadas com cores e  formas diferentes. A relação entre a 
+#|   massa corporal e o comprimento  das nadadeiras é praticamente a 
+#|   mesma para essas três espécies, e os pinguins-gentoo são maiores do 
+#|   que os pinguins das outras duas  espécies.
 
 ggplot(pinguins, aes(x = comprimento_nadadeira, y = massa_corporal)) +
   geom_point(aes(color = especie, shape = especie)) +
@@ -401,10 +406,11 @@ ggplot(data = pinguins) +
 #| echo: false
 #| warning: false
 #| fig-alt: |
-#|   A scatterplot of body mass vs. flipper length of pinguins, colored 
-#|   by bill depth. A smooth curve of the relationship between body mass 
-#|   and flipper length is overlaid. The relationship is positive, 
-#|   fairly linear, and moderately strong.
+#|   Um gráfico de dispersão da massa corporal em função do comprimento 
+#|   da  nadadeira dos pinguins, colorido pela profundidade do bico. Uma 
+#|   curva suave da relação entre a massa corporal e o comprimento da 
+#|   nadadeira está sobreposta. A relação é positiva, razoavelmente 
+#|   linear e moderadamente forte.
 
 ggplot(
   data = pinguins,
@@ -427,29 +433,28 @@ ggplot(
   geom_smooth(se = FALSE)
 ```
 
-10. Esses dois gráficos serão diferentes?
-    Por que sim ou por que não?
+10. Esses dois gráficos serão diferentes? Por que sim ou por que não?
 
-    ```{r}
-    #| eval: false
+```{r}
+#| eval: false
 
-    ggplot(
-      data = pinguins,
-      mapping = aes(x = comprimento_nadadeira, y = massa_corporal)
-    ) +
-      geom_point() +
-      geom_smooth()
+ggplot(
+  data = pinguins,
+  mapping = aes(x = comprimento_nadadeira, y = massa_corporal)
+) +
+  geom_point() +
+  geom_smooth()
 
-    ggplot() +
-      geom_point(
-        data = pinguins,
-        mapping = aes(x = comprimento_nadadeira, y = massa_corporal)
-      ) +
-      geom_smooth(
-        data = pinguins,
-        mapping = aes(x = comprimento_nadadeira, y = massa_corporal)
-      )
-    ```
+ggplot() +
+  geom_point(
+    data = pinguins,
+    mapping = aes(x = comprimento_nadadeira, y = massa_corporal)
+  ) +
+  geom_smooth(
+    data = pinguins,
+    mapping = aes(x = comprimento_nadadeira, y = massa_corporal)
+  )
+```
 
 ## Chamadas ggplot2 {#sec-ggplot2-calls}
 
@@ -502,9 +507,8 @@ A altura das barras exibe quantas observações ocorreram com cada valor `x`.
 
 ```{r}
 #| fig-alt: |
-#|   A bar chart of frequencies of especie of pinguins: Adelie 
-#|   (approximately 150), Chinstrap (approximately 90), Gentoo 
-#|   (approximately 125).
+#|   Um gráfico de barras das frequências das espécies de pinguins: 
+#|   Pinguim-de-Adélia (aproximadamente 150), Pinguim-de-barbicha (aproximadamente 90), Pinguim-Gentoo (aproximadamente 125).
 
 ggplot(pinguins, aes(x = especie)) +
   geom_bar()
@@ -515,10 +519,11 @@ Para isso, é necessário transformar a variável em um fator (como o R lida com
 
 ```{r}
 #| fig-alt: |
-#|   A bar chart of frequencies of especie of pinguins, where the bars are 
-#|   ordered in decreasing order of their heights (frequencies): Adelie 
-#|   (approximately 150), Gentoo (approximately 125), Chinstrap 
-#|   (approximately 90).
+#|   Um gráfico de barras das frequências das espécies de pinguins, onde 
+#|   as barras estão ordenadas em ordem decrescente das alturas 
+#|   (frequências): Pinguim-de-Adélia (aproximadamente 150), 
+#|   Pinguim-Gentoo (aproximadamente 125), Pinguim-de-barbicha 
+#|   (aproximadamente 90).
 
 ggplot(pinguins, aes(x = fct_infreq(especie))) +
   geom_bar()
@@ -536,8 +541,9 @@ Uma visualização comumente usada para distribuições de variáveis contínuas
 ```{r}
 #| warning: false
 #| fig-alt: |
-#|   A histogram of body masses of pinguins. The distribution is unimodal 
-#|   and right skewed, ranging between approximately 2500 to 6500 grams.
+#|   Um histograma da massa corporal dos pinguins. A distribuição é 
+#|   unimodal e inclinada para a direita, variando entre aproximadamente 
+#|   2500 e 6500 gramas.
 
 ggplot(pinguins, aes(x = massa_corporal)) +
   geom_histogram(binwidth = 200)
@@ -557,10 +563,12 @@ Uma largura de intervalo de 200 proporciona um balanço mais adequado.
 #| layout-ncol: 2
 #| fig-width: 3
 #| fig-alt: |
-#|   Two histograms of body masses of pinguins, one with binwidth of 20 
-#|   (left) and one with binwidth of 2000 (right). The histogram with binwidth 
-#|   of 20 shows lots of ups and downs in the heights of the bins, creating a 
-#|   jagged outline. The histogram  with binwidth of 2000 shows only three bins.
+#|   Dois histogramas da massa corporal de pinguins, um com largura de 
+#|   intervalo de 20 (esquerda) e outro com largura de intervalo de 2000 
+#|   (direita). O histograma com largura de intervalo de 20 mostra muitos
+#|   altos e baixos nas alturas das barras, criando um contorno 
+#|   irregular. O histograma com largura de intervalo de 2000 mostra 
+#|   apenas três compartimentos.
 
 ggplot(pinguins, aes(x = massa_corporal)) +
   geom_histogram(binwidth = 20)
@@ -578,8 +586,9 @@ Ela mostra menos detalhes do que um histograma, mas pode facilitar a obtenção 
 
 ```{r}
 #| fig-alt: |
-#|   A density plot of body masses of pinguins. The distribution is unimodal 
-#|   and right skewed, ranging between approximately 2500 to 6500 grams.
+#|   Um gráfico de densidade da massa corporal dos pinguins. A distribuição é 
+#|   unimodal e inclinada para a direita, variando entre aproximadamente 
+#|   2500 e 6500 gramas.
 
 ggplot(pinguins, aes(x = massa_corporal)) +
   geom_density()
@@ -634,10 +643,9 @@ Conforme mostrado em @fig-eda-boxplot, cada boxplot consiste em:
 #| label: fig-eda-boxplot
 #| echo: false
 #| fig-cap: |
-#|   Diagram depicting how a boxplot is created.
+#|   Diagrama sobre como um boxplot é criado.
 #| fig-alt: |
-#|   A diagram depicting how a boxplot is created following the steps outlined 
-#|   above.
+#|   Um diagrama exibindo como um boxplot é criado seguindo os passos acima.
 
 knitr::include_graphics("images/EDA-boxplot.png")
 ```
@@ -647,12 +655,14 @@ Vamos dar uma olhada na distribuição da massa corporal por espécie usando `ge
 ```{r}
 #| warning: false
 #| fig-alt: |
-#|   Side-by-side box plots of distributions of body masses of Adelie, 
-#|   Chinstrap, and Gentoo pinguins. The distribution of Adelie and 
-#|   Chinstrap pinguins' body masses appear to be symmetric with 
-#|   medians around 3750 grams. The median body mass of Gentoo pinguins 
-#|   is much higher, around 5000 grams, and the distribution of the 
-#|   body masses of these pinguins appears to be somewhat right skewed.
+#|   Boxplots lado a lado da distribuição da massa corporal de 
+#|   Pinguim-de-adélia, Pinguim-de-barbicha e Pinguim-gentoo. A 
+#|   distribuição das massas corporais dos pinguins-de-Adélia e 
+#|   Pinguim-de-barbicha parece ser simétrica, com medianas em torno de 
+#|   3.750 gramas. A massa corporal mediana dos Pinguim-gentoo é muito 
+#|   mais alta, em torno de 5.000 gramas, e a distribuição das massas 
+#|   corporais desses pinguins parece ser um pouco inclinada para a 
+#|   direita.
 
 ggplot(pinguins, aes(x = especie, y = massa_corporal)) +
   geom_boxplot()
@@ -663,9 +673,9 @@ Como alternativa, podemos criar gráficos de densidade com `geom_density()`.
 ```{r}
 #| warning: false
 #| fig-alt: |
-#|   A density plot of body masses of pinguins by especie of pinguins. Each 
-#|   especie (Adelie, Chinstrap, and Gentoo) is represented with different 
-#|   colored outlines for the density curves.
+#|   Um gráfico de densidade da massa corporal de pinguins separado por 
+#|   espécie. Cada espécie (Pinguim-de-adélia, Pinguim-de-barbicha e 
+#|   Pinguim-gentoo) é representada por um contorno colorido diferente em #|   cada curva de densidade.
 
 ggplot(pinguins, aes(x = massa_corporal, color = especie)) +
   geom_density(linewidth = 0.75)
@@ -680,10 +690,11 @@ No gráfico a seguir, ela está *definida* como 0.5.
 ```{r}
 #| warning: false
 #| fig-alt: |
-#|   A density plot of body masses of pinguins by especie of pinguins. Each 
-#|   especie (Adelie, Chinstrap, and Gentoo) is represented in different 
-#|   colored outlines for the density curves. The density curves are also 
-#|   filled with the same colors, with some transparency added.
+#|   Um gráfico de densidade da massa corporal de pinguins separado por 
+#|   espécie. Cada espécie (Pinguim-de-adélia, Pinguim-de-barbicha e 
+#|   Pinguim-gentoo) é representada por um contorno colorido diferente em #|   cada curva de densidade. As curvas de densidade também são 
+#|   preenchidas com as mesmas cores, com alguma transparência 
+#|   adicionada.
 
 ggplot(pinguins, aes(x = massa_corporal, color = especie, fill = especie)) +
   geom_density(alpha = 0.5)
@@ -705,7 +716,7 @@ Mas não temos uma boa noção do equilíbrio percentual em cada ilha.
 
 ```{r}
 #| fig-alt: |
-#|   Bar plots of penguin especie by ilha (Biscoe, Dream, and Torgersen)
+#|   Gráfico de barras das espécies de pinguins por ilha (Biscoe, Dream, e Torgersen)
 ggplot(pinguins, aes(x = ilha, fill = especie)) +
   geom_bar()
 ```
@@ -715,9 +726,9 @@ Usando esse gráfico, podemos ver que todos os Pinguim-gentoo vivem na ilha Bisc
 
 ```{r}
 #| fig-alt: |
-#|   Bar plots of penguin especie by ilha (Biscoe, Dream, and Torgersen)
-#|   the bars are scaled to the same height, making it a relative frequencies 
-#|   plot
+#|   Gráfico de barras das espécies de pinguins por ilha (Biscoe, Dream, 
+#|   e Torgersen). As barras estão redimensionadas para terem a mesma 
+#|   altura, tornando este um gráfico de frequência relativa.
 
 ggplot(pinguins, aes(x = ilha, fill = especie)) +
   geom_bar(position = "fill")
@@ -733,9 +744,7 @@ Um gráfico de dispersão é provavelmente o gráfico mais usado para visualizar
 ```{r}
 #| warning: false
 #| fig-alt: |
-#|   A scatterplot of body mass vs. flipper length of pinguins. The plot 
-#|   displays a positive, linear, relatively strong relationship between 
-#|   these two variables.
+#|   Um gráfico de dispersão da massa corporal em função do comprimento da nadadeira dos pinguins. O gráfico mostra uma relação positiva, linear e relativamente forte entre essas duas variáveis.
 
 ggplot(pinguins, aes(x = comprimento_nadadeira, y = massa_corporal)) +
   geom_point()
@@ -749,13 +758,14 @@ Por exemplo, no gráfico de dispersão a seguir, as cores dos pontos (*color*) r
 ```{r}
 #| warning: false
 #| fig-alt: |
-#|   A scatterplot of body mass vs. flipper length of pinguins. The plot 
-#|   displays a positive, linear, relatively strong relationship between 
-#|   these two variables. The points are colored based on the especie of the 
-#|   pinguins and the shapes of the points represent ilhas (round points are 
-#|   Biscoe ilha, triangles are Dream ilha, and squared are Torgersen 
-#|   ilha). The plot is very busy and it's difficult to distinguish the shapes
-#|   of the points.
+#|   Um gráfico de dispersão da massa corporal em função do comprimento 
+#|   da nadadeira dos pinguins. O gráfico mostra uma relação positiva, 
+#|   linear e relativamente forte entre essas duas variáveis. Os pontos 
+#|   são coloridos com base na espécie dos pinguins e as formas dos 
+#|   pontos representam ilhas (os pontos redondos são a ilha Biscoe, os 
+#|   triângulos são a ilha Dream e os quadrados são a ilha Torgersen). O 
+#|   gráfico é muito carregado e é difícil distinguir as formas dos 
+#|   pontos.
 
 ggplot(pinguins, aes(x = comprimento_nadadeira, y = massa_corporal)) +
   geom_point(aes(color = especie, shape = ilha))
@@ -775,10 +785,11 @@ A variável que você passa para `facet_wrap()` deve ser categórica.
 #| fig-width: 8
 #| fig-asp: 0.33
 #| fig-alt: |
-#|   A scatterplot of body mass vs. flipper length of pinguins. The shapes and 
-#|   colors of points represent especie. pinguins from each ilha are on a 
-#|   separate facet. Within each facet, the relationship between body mass and 
-#|   flipper length is positive, linear, relatively strong. 
+#|   Um gráfico de dispersão da massa corporal em função do comprimento 
+#|   da nadadeira dos pinguins. As formas e cores dos pontos representam 
+#|   as espécies. Os pinguins de cada ilha estão em uma faceta separada. 
+#|   Em cada faceta, a relação entre a massa corporal e o comprimento da 
+#|   nadadeira é positiva, linear e relativamente forte. 
 
 ggplot(pinguins, aes(x = comprimento_nadadeira, y = massa_corporal)) +
   geom_point(aes(color = especie, shape = especie)) +

--- a/data-visualize.qmd
+++ b/data-visualize.qmd
@@ -859,7 +859,7 @@ Isso salvará o gráfico no seu diretório de trabalho, um conceito sobre o qual
 
 Se você não especificar a largura `width` e a altura `height`, elas serão tiradas das dimensões do dispositivo de plotagem atual.
 Para obter um código reprodutível, você deverá especificá-los.
-Você pode obter mais informações sobre `ggsave()` na documentação.
+Você pode obter mais informações sobre a função `ggsave()` na documentação.
 
 De modo geral, entretanto, recomendamos que você monte seus relatórios finais usando o Quarto, um sistema de autoria reproduzível que permite intercalar seu código e sua escrita e incluir automaticamente seus gráficos em seus relatórios.
 Você saberá mais sobre o Quarto em @sec-quarto.

--- a/data-visualize.qmd
+++ b/data-visualize.qmd
@@ -283,7 +283,7 @@ ggplot(
 Adicionamos linhas com sucesso, mas esse gráfico não se parece com o gráfico do @sec-ultimate-goal, que tem apenas uma linha para todo o conjunto de dados, em vez de linhas separadas para cada espécie de pinguim.
 
 Quando os mapeamentos estéticos são definidos em `ggplot()`, no nível **global**, eles são passados para cada uma das camadas de geometria (geom) subsequentes do gráfico.
-Entretanto, cada função geom no ggplot2 também pode receber um argumento `mapping`, que permite mapeamentos estéticos em nível *local* que são adicionados àqueles herdados do nível global.
+Entretanto, cada função geom no ggplot2 também pode receber um argumento `mapping`, que permite mapeamentos estéticos em nível **local** que são adicionados àqueles herdados do nível global.
 Como queremos que os pontos sejam coloridos com base na espécie, mas não queremos que as linhas sejam separadas para eles, devemos especificar `color = especie` somente para `geom_point()`.
 
 ```{r}

--- a/data-visualize.qmd
+++ b/data-visualize.qmd
@@ -163,7 +163,7 @@ Esse não é um gráfico muito interessante, mas você pode pensar nele como uma
 
 ```{r}
 #| fig-alt: |
-#|   Uma área de gráfico vazia em cinza
+#|   Uma área de plotagem vazia em cinza
 
 ggplot(data = pinguins)
 ```

--- a/data-visualize.qmd
+++ b/data-visualize.qmd
@@ -12,7 +12,7 @@ source("_common.R")
 
 O R possui diversos sistemas para construir gráficos, mas o ggplot2 é um dos mais elegantes e versáteis.
 O ggplot2 implementa a **gramática dos gráficos**, um sistema coerente para descrever e construir gráficos.
-Com o ggplot2 você pode fazer mais rápido, ao aprender um sistema e aplicá-lo em muitos lugares.
+Com o ggplot2 você pode fazer mais, e mais rápido, ao aprender um sistema e aplicá-lo em muitos lugares.
 
 Este capítulo irá te ensinar como visualizar seus dados usando o **ggplot2**.
 Nós vamos começar criando um gráfico de dispersão simples e usá-lo para introduzir o mapeamento de atributos estéticos (*aesthetic*) e geometrias -- os blocos fundamentais na construção do ggplot2.

--- a/data-visualize.qmd
+++ b/data-visualize.qmd
@@ -267,7 +267,7 @@ E especificaremos que queremos desenhar a linha de melhor ajuste com base em um 
 ```{r}
 #| warning: false
 #| fig-alt: |
-#|   Um gráfico de dispersão da massa corporal em função o comprimento da
+#|   Um gráfico de dispersão da massa corporal em função do comprimento da
 #|   nadadeira dos pinguins. Sobrepostas ao gráfico de dispersão estão 
 #|   três curvas suavizadas que mostram a relação entre essas variáveis 
 #|   para cada espécie (Pinguim-de-adélia, Pinguim-de-barbicha e 

--- a/data-visualize.qmd
+++ b/data-visualize.qmd
@@ -36,7 +36,7 @@ Ela também te diz quais funções do tidyverse possuem conflitos com as funçã
 [^data-visualize-1]: Você pode eliminar essa mensagem e forçar com que a resolução de conflitos aconteça sob demanda utilizando o pacote conflicted, que se torna mais importante à medida que carrega mais pacotes.
     Você pode ler mais sobre o pacote conflicted no endereço <https://conflicted.r-lib.org>.
 
-Se você rodar este código e receber a mensagem de erro `there is no package called 'tidyverse'`, você precisará instalar o pacote antes, e então rodar `library()` novamente.
+Se você rodar este código e receber a mensagem de erro `there is no package called 'tidyverse'`, você precisará instalar o pacote antes usando a função `install.packages()` ou a interface de instalação do RStudio, e então rodar `library()` novamente.
 
 ```{r}
 #| eval: false

--- a/data-visualize.qmd
+++ b/data-visualize.qmd
@@ -30,7 +30,7 @@ Para acessar os bancos de dados, páginas de ajuda e funções utilizadas neste 
 library(tidyverse)
 ```
 
-Essa única linha de código carrega o essencial do tidyverse; os pacotes que você irá utilizar em quase toda análise de dados.
+Essa única linha de código carrega os pacotes essenciais do tidyverse, que você irá utilizar em quase toda análise de dados.
 Ela também te diz quais funções do tidyverse possuem conflitos com as função do R base (ou de outro pacote que você tenha carregado)[^data-visualize-1].
 
 [^data-visualize-1]: Você pode eliminar essa mensagem e forçar com que a resolução de conflitos aconteça sob demanda utilizando o pacote conflicted, que se torna mais importante à medida que carrega mais pacotes.

--- a/data-visualize.qmd
+++ b/data-visualize.qmd
@@ -222,7 +222,7 @@ Antes de adicionarmos mais camadas a esse gráfico, vamos parar por um momento e
 
 > Removed 2 rows containing missing values (`geom_point()`).
 
-Estamos vendo essa mensagem porque há dois pinguins em nosso conjunto de dados com valores ausentes de massa corporal e/ou comprimento da nadadeira e o ggplot2 não tem como representá-los no gráfico sem esses dois valores.
+Estamos vendo essa mensagem porque há dois pinguins em nosso conjunto de dados com valores faltantes (*missing values - *NA*) de massa corporal e/ou comprimento da nadadeira e o ggplot2 não tem como representá-los no gráfico sem esses dois valores.
 Assim como o R, o ggplot2 adota a filosofia de que os valores ausentes nunca devem desaparecer silenciosamente.
 Esse tipo de aviso é provavelmente um dos tipos mais comuns de avisos que você verá ao trabalhar com dados reais - os valores ausentes são um problema muito comum e você aprenderá mais sobre eles ao longo do livro, especialmente em @sec-missing-values.
 Nos demais gráficos deste capítulo, suprimiuprimir esse aviso para que ele não seja mostrado em cada gráfico que fizermos.

--- a/data-visualize.qmd
+++ b/data-visualize.qmd
@@ -57,7 +57,7 @@ library(ggthemes)
 ## Primeiros passos
 
 Os pinguins com nadadeiras mais compridas pesam mais ou menos que pinguins com nadadeiras curtas?
-Você provavelmentejá tem uma resposta, mas tente torná-la mais precisa.
+Você provavelmente já tem uma resposta, mas tente torná-la mais precisa.
 Como é a relação entre o comprimento da nadadeira e massa corporal?
 Ela é positiva?
 Negativa?

--- a/data-visualize.qmd
+++ b/data-visualize.qmd
@@ -762,7 +762,7 @@ ggplot(pinguins, aes(x = comprimento_nadadeira, y = massa_corporal)) +
 ```
 
 No entanto, mapear muitos atributos estéticos a um gráfico faz com que ele fique desordenado e difícil de entender.
-Outra maneira, que é particularmente útil para variáveis categóricas, é dividir seu gráfico em **facetas**, subdivisões que exibem um subconjunto dos dados cada uma.
+Outra maneira, que é particularmente útil para variáveis categóricas, é dividir seu gráfico em **facetas**, subdivisões ou janelas que exibem um subconjunto dos dados cada uma.
 
 Para separar seu gráfico em facetas por uma única variável, use `facet_wrap()`.
 O primeiro argumento de `facet_wrap()` é uma fórmula[^data-visualize-3], que você cria com `~` seguido do nome de uma variável.

--- a/data-visualize.qmd
+++ b/data-visualize.qmd
@@ -34,7 +34,7 @@ Essa única linha de código carrega os pacotes essenciais do tidyverse, que voc
 Ela também te diz quais funções do tidyverse possuem conflitos com as função do R base (ou de outro pacote que você tenha carregado)[^data-visualize-1].
 
 [^data-visualize-1]: Você pode eliminar essa mensagem e forçar com que a resolução de conflitos aconteça sob demanda utilizando o pacote conflicted, que se torna mais importante à medida que carrega mais pacotes.
-    Você pode ler mais sobre o pacote conflicted em <https://conflicted.r-lib.org>.
+    Você pode ler mais sobre o pacote conflicted no endereço <https://conflicted.r-lib.org>.
 
 Se você rodar este código e receber a mensagem de erro `there is no package called 'tidyverse'`, você precisará instalar o pacote antes, e então rodar `library()` novamente.
 

--- a/data-visualize.qmd
+++ b/data-visualize.qmd
@@ -157,7 +157,7 @@ ggplot(pinguins, aes(x = comprimento_nadadeira, y = massa_corporal)) +
 
 Vamos recriar esse gráfico passo a passo.
 
-Com o ggplot2, você inicia um gráfico com a função `ggplot()`, definindo um objeto de gráfico ao qual você adiciona **camadas**.
+No ggplot2, você inicia um gráfico com a função `ggplot()`, definindo um objeto de gráfico ao qual você adiciona **camadas**.
 O primeiro argumento de `ggplot()` é o conjunto de dados a ser usado no gráfico e, portanto, `ggplot(data = pinguins)` cria um gráfico vazio que está preparado para exibir os dados dos `pinguins`, mas, como ainda não dissemos como visualizá-los, por enquanto ele está vazio.
 Esse não é um gráfico muito interessante, mas você pode pensar nele como uma tela vazia na qual você pintará as camadas restantes do seu gráfico.
 

--- a/data-visualize.qmd
+++ b/data-visualize.qmd
@@ -909,7 +909,7 @@ Não se preocupe se a ajuda não parecer muito útil - em vez disso, pule para o
 
 Se isso não ajudar, leia atentamente a mensagem de erro.
 Às vezes, a resposta estará escondida lá!
-Mas quando você é novo no R, mesmo que a resposta esteja na mensagem de erro, talvez você ainda não saiba como entendê-la.
+Mas quando você é iniciante no R, mesmo que a resposta esteja na mensagem de erro, talvez você ainda não saiba como entendê-la.
 Outra ferramenta excelente é o Google: tente pesquisar a mensagem de erro no Google, pois é provável que outra pessoa tenha tido o mesmo problema e tenha obtido ajuda on-line.
 
 ## Resumo

--- a/data-visualize.qmd
+++ b/data-visualize.qmd
@@ -47,7 +47,7 @@ library(tidyverse)
 
 Você só precisa instalar um pacote uma vez, mas precisa carregá-lo sempre que iniciar uma nova sessão.
 
-Além do tidyverse, nós também usaremos o pacote **dados**, que inclui um banco de dados com medidas corporais de pinguins de três ilhas do Arquipélago Palmer, junto do pacote ggthemes, que fornece uma paleta de cores segura para daltônicos.
+Além do tidyverse, nós também usaremos o pacote **dados**, que inclui um banco de dados com medidas corporais de pinguins de três ilhas do Arquipélago Palmer, junto do pacote ggthemes, que fornece uma paleta de cores segura para pessoas com daltonismo.
 
 ```{r}
 library(dados)

--- a/data-visualize.qmd
+++ b/data-visualize.qmd
@@ -612,7 +612,7 @@ ggplot(pinguins, aes(x = especie)) +
 ## Visualizando relações
 
 Para visualizar uma relação, precisamos ter pelo menos duas variáveis mapeadas para os atributos estéticos de um gráfico.
-Nas seções a seguir, você aprenderá sobre os gráficos comumente usados para visualizar relações entre duas ou mais variáveis e os geoms usados para criá-los.
+Nas seções a seguir, você aprenderá sobre os gráficos comumente usados para visualizar relações entre duas ou mais variáveis e as geometrias usados para criá-los.
 
 ### Uma variável numérica e uma variável categórica
 

--- a/data-visualize.qmd
+++ b/data-visualize.qmd
@@ -332,7 +332,7 @@ Observe que a legenda também é atualizada automaticamente para refletir as dif
 E, finalmente, podemos melhorar os rótulos do nosso gráfico usando a função `labs()` em uma nova camada.
 Alguns dos argumentos de `labs()` podem ser autoexplicativos: `title` adiciona um título e `subtitle` adiciona um subtítulo ao gráfico.
 Outros argumentos correspondem aos mapeamentos estéticos, `x` é o rótulo do eixo x, `y` é o rótulo do eixo y e `color` e `shape` definem o rótulo da legenda.
-Além disso, podemos aprimorar a paleta de cores para que seja segura para daltônicos com a função `scale_color_colorblind()` do pacote ggthemes.
+Além disso, podemos aprimorar a paleta de cores para que seja segura para pessoas com daltonismo com a função `scale_color_colorblind()` do pacote ggthemes.
 
 ```{r}
 #| warning: false

--- a/data-visualize.qmd
+++ b/data-visualize.qmd
@@ -70,7 +70,7 @@ Vamos criar visualizações que podemos usar para responder essas perguntas.
 ### O data frame `pinguins`
 
 Você pode testar suas respostas à essas questões usando o **data frame** `pinguins` encontrado no pacote `dados` (usando `dados::pinguins`).
-Um *data frame* é uma coleção retangular de variáveis (nas colunas) e observações (nas linhas).
+Um *data frame* é uma coleção tabular (formato de tabela) de variáveis (nas colunas) e observações (nas linhas).
 `pinguins` contém `r nrow(pinguins)` observações coletadas e disponibilizadas pela Dra.
 Kristen Gorman e pelo PELD Estação Palmer, Antártica[^data-visualize-2].
 

--- a/data-visualize.qmd
+++ b/data-visualize.qmd
@@ -467,7 +467,7 @@ ggplot(
 ```
 
 Normalmente, o primeiro ou os dois primeiros argumentos de uma função são tão importantes que você deve saber usar de cor.
-Os dois primeiros argumentos de `ggplot()` são `data` e `mapping`; no restante do livro, não forneceremos esses nomes.
+Os dois primeiros argumentos de `ggplot()` são `data` e `mapping`; no restante do livro, não escreveremos esses nomes.
 Isso economiza digitação e, ao reduzir a quantidade de texto extra, facilita a visualização das diferenças entre os gráficos.
 Essa é uma preocupação de programação realmente importante, à qual voltaremos em @sec-functions.
 

--- a/data-visualize.qmd
+++ b/data-visualize.qmd
@@ -282,7 +282,7 @@ ggplot(
 
 Adicionamos linhas com sucesso, mas esse gráfico não se parece com o gráfico do @sec-ultimate-goal, que tem apenas uma linha para todo o conjunto de dados, em vez de linhas separadas para cada espécie de pinguim.
 
-Quando os mapeamentos estéticos são definidos em `ggplot()`, no nível *global*, eles são passados para cada uma das camadas geom subsequentes do gráfico.
+Quando os mapeamentos estéticos são definidos em `ggplot()`, no nível **global**, eles são passados para cada uma das camadas de geometria (geom) subsequentes do gráfico.
 Entretanto, cada função geom no ggplot2 também pode receber um argumento `mapping`, que permite mapeamentos estéticos em nível *local* que são adicionados àqueles herdados do nível global.
 Como queremos que os pontos sejam coloridos com base na espécie, mas não queremos que as linhas sejam separadas para eles, devemos especificar `color = especie` somente para `geom_point()`.
 

--- a/data-visualize.qmd
+++ b/data-visualize.qmd
@@ -692,7 +692,7 @@ ggplot(pinguins, aes(x = massa_corporal, color = especie, fill = especie)) +
 Observe a terminologia que usamos aqui:
 
 -   Nós **mapeamos** variáveis para atributos estéticos se quisermos que o atributo visual representado por esse atributo varie de acordo com os valores dessa variável.
--   Caso contrário, nós *definimos* o valor de um atributo estético.
+-   Caso contrário, nós **definimos** o valor de um atributo estético.
 
 ### Duas variáveis categóricas
 

--- a/data-visualize.qmd
+++ b/data-visualize.qmd
@@ -188,7 +188,7 @@ ggplot(
 )
 ```
 
-Nossa tela vazia agora tem mais estrutura: está claro onde os comprimentos das nadadeiras serão exibidos (no eixo x) e onde as massas corporais serão exibidas (no eixo y).
+Nossa tela vazia agora está mais estruturada: está claro onde os comprimentos das nadadeiras serão exibidos (no eixo x) e onde as massas corporais serão exibidas (no eixo y).
 Mas os pinguins em si ainda não estão no gráfico.
 Isso ocorre porque ainda não definimos, em nosso código, como representar as observações de nosso *data frame* em nosso gráfico.
 

--- a/data-visualize.qmd
+++ b/data-visualize.qmd
@@ -434,7 +434,7 @@ ggplot(
     #| eval: false
 
     ggplot(
-      datai = pinguins,
+      data = pinguins,
       mapping = aes(x = comprimento_nadadeira, y = massa_corporal)
     ) +
       geom_point() +

--- a/data-visualize.qmd
+++ b/data-visualize.qmd
@@ -694,7 +694,8 @@ No gráfico a seguir, ela está *definida* como 0.5.
 #| fig-alt: |
 #|   Um gráfico de densidade da massa corporal de pinguins separado por 
 #|   espécie. Cada espécie (Pinguim-de-adélia, Pinguim-de-barbicha e 
-#|   Pinguim-gentoo) é representada por um contorno colorido diferente em #|   cada curva de densidade. As curvas de densidade também são 
+#|   Pinguim-gentoo) é representada por um contorno colorido diferente em 
+#|   cada curva de densidade. As curvas de densidade também são 
 #|   preenchidas com as mesmas cores, com alguma transparência 
 #|   adicionada.
 

--- a/data-visualize.qmd
+++ b/data-visualize.qmd
@@ -903,7 +903,7 @@ ggplot(data = milhas)
 + geom_point(mapping = aes(x = cilindrada, y = rodovia))
 ```
 
-Se você ainda estiver com dificuldades, tente a ajuda.
+Se você ainda estiver com dificuldades, tente a ajuda (painel *Help*).
 Você pode obter ajuda sobre qualquer função do R executando `?nome_da_função` no console ou selecionando o nome da função e pressionando F1 no RStudio.
 Não se preocupe se a ajuda não parecer muito útil - em vez disso, pule para os exemplos e procure um código que corresponda ao que você está tentando fazer.
 

--- a/data-visualize.qmd
+++ b/data-visualize.qmd
@@ -21,7 +21,7 @@ Terminaremos salvando seus gráficos e com dicas de resolução de problemas.
 
 ### Pré-requisitos
 
-Este capítulo tem foco no ggplot2, um dos pacotes principais do tidyverse.
+Este capítulo tem foco no ggplot2, um dos principais pacotes do tidyverse.
 Para acessar os bancos de dados, páginas de ajuda e funções utilizadas neste capítulo, carregue o tidyverse executando:
 
 ```{r}

--- a/data-visualize.qmd
+++ b/data-visualize.qmd
@@ -691,7 +691,7 @@ ggplot(pinguins, aes(x = massa_corporal, color = especie, fill = especie)) +
 
 Observe a terminologia que usamos aqui:
 
--   Nós *mapeamos* variáveis para atributos estéticos se quisermos que o atributo visual representado por esse atributo varie com base nos valores dessa variável.
+-   Nós **mapeamos** variáveis para atributos estéticos se quisermos que o atributo visual representado por esse atributo varie de acordo com os valores dessa variável.
 -   Caso contrário, nós *definimos* o valor de um atributo estético.
 
 ### Duas variáveis categóricas

--- a/data-visualize.qmd
+++ b/data-visualize.qmd
@@ -260,7 +260,7 @@ O ggplot2 também adicionará uma legenda que explica quais valores correspondem
 Agora vamos adicionar mais uma camada: uma curva suave que exibe a relação entre a massa corporal e o comprimento das nadadeiras.
 Antes de prosseguir, consulte o código acima e pense em como podemos adicionar isso ao nosso gráfico existente.
 
-Como esse é uma nova geometria que representa nossos dados, adicionaremos uma nova geometria como uma camada sobre o nossa geometria de pontos: `geom_smooth()`.
+Como essa é uma nova geometria que representa nossos dados, adicionaremos uma nova geometria como uma camada sobre o nossa geometria de pontos: `geom_smooth()`.
 E especificaremos que queremos desenhar a linha de melhor ajuste com base em um modelo linear (`l`inear `m`odel em inglês) com `method = "lm"`.
 
 ```{r}

--- a/data-visualize.qmd
+++ b/data-visualize.qmd
@@ -215,7 +215,7 @@ ggplot(
 ```
 
 Agora temos algo que se parece com o que poderíamos chamar de "gráfico de dispersão".
-Ele ainda não corresponde ao nosso gráfico de "objetivo final", mas, usando esse gráfico, podemos começar a responder à pergunta que motivou nossa exploração: "Como é a relação entre o comprimento da nadadeira e a massa corporal?" A relação parece ser positiva (à medida que o comprimento da nadadeira aumenta, a massa corporal também aumenta), razoavelmente linear (os pontos estão agrupados em torno de uma linha em vez de uma curva) e moderadamente forte (não há muita dispersão em torno dessa linha).
+Ele ainda não corresponde ao nosso gráfico mostrado no início da seção "objetivo final", mas, usando esse gráfico, podemos começar a responder à pergunta que motivou nossa exploração: "Como é a relação entre o comprimento da nadadeira e a massa corporal?" A relação parece ser positiva (à medida que o comprimento da nadadeira aumenta, a massa corporal também aumenta), razoavelmente linear (os pontos estão agrupados em torno de uma linha em vez de uma curva) e moderadamente forte (não há muita dispersão em torno dessa linha).
 Os pinguins com nadadeiras mais longas geralmente são maiores em termos de massa corporal.
 
 Antes de adicionarmos mais camadas a esse gráfico, vamos parar por um momento e revisar a mensagem de aviso que recebemos:

--- a/data-visualize.qmd
+++ b/data-visualize.qmd
@@ -862,7 +862,7 @@ Para obter um código reprodutível, você deverá especificá-los.
 Você pode obter mais informações sobre a função `ggsave()` na documentação.
 
 De modo geral, entretanto, recomendamos que você monte seus relatórios finais usando o Quarto, um sistema de autoria reproduzível que permite intercalar seu código e sua escrita e incluir automaticamente seus gráficos em seus relatórios.
-Você saberá mais sobre o Quarto em @sec-quarto.
+Você aprenderá mais sobre o Quarto em @sec-quarto.
 
 ### Exercícios
 

--- a/data-visualize.qmd
+++ b/data-visualize.qmd
@@ -22,7 +22,7 @@ Terminaremos salvando seus gráficos e com dicas de resolução de problemas.
 ### Pré-requisitos
 
 Este capítulo tem foco no ggplot2, um dos principais pacotes do tidyverse.
-Para acessar os bancos de dados, páginas de ajuda e funções utilizadas neste capítulo, carregue o tidyverse executando:
+Para acessar os bancos de dados, páginas de ajuda e funções utilizadas neste capítulo, você deve carregar o tidyverse executando o comando:
 
 ```{r}
 #| label: setup

--- a/data-visualize.qmd
+++ b/data-visualize.qmd
@@ -291,7 +291,7 @@ Como queremos que os pontos sejam coloridos com base na espécie, mas não quere
 ```{r}
 #| warning: false
 #| fig-alt: |
-#|   Um gráfico de dispersão da massa corporal em função o comprimento da
+#|   Um gráfico de dispersão da massa corporal em função do comprimento da
 #|   nadadeira dos pinguins. Sobreposta ao gráfico de dispersão está
 #|   uma única linha de melhor ajuste que mostra a relação entre essas 
 #|   variáveis para cada espécie (Pinguim-de-adélia, Pinguim-de-barbicha 


### PR DESCRIPTION
Algumas observações sobre a tradução do Capítulo data-visualize.qmd (#3) :

Estou enviando o PR quase finalizado pois viajo em coleta segunda e não terei muito tempo pelos próximos 10 dias.

Faltou traduzir apenas os textos alternativos (fig-alt) dos gráficos.

Traduzi os datasets utilizados de acordo com o pacote {dados}, não utilizando os pacote palmerpenguins, diamonds e mtcars.

A figura explicativa do boxplot ainda deve ser traduzida (externamente)

Algumas traduções que segui para tentar facilitar a leitura. Fiquem à vontade para mudar:

- mapping: mapeamento
- aesthetics: atributos estéticos
- scaling: dimensionamento
- geometrical object: geometria
- the geom: a geom
- labels: rótulos (eu até pensei em títulos mas pode ficar confuso)
- binwidth: largura de intervalo
- data frame: data frame

Talvez eu tenha mudado o estilo de tradução durante o trabalho porque o capítulo era bem longo.