### PR TITLE
Tradução: logicals.qmd

### DIFF
--- a/logicals.qmd
+++ b/logicals.qmd
@@ -11,7 +11,7 @@ source("_common.R")
 ## Introdução
 
 Neste capítulo, você aprenderá ferramentas para trabalhar com vetores lógicos.
-Vetores lógicos são a forma mais simples de vetores, pois cada elemento pode ter apenas um dos três possíveis valores:: `TRUE`, `FALSE` e `NA`.
+Vetores lógicos são a forma mais simples de vetores, pois cada elemento pode ter apenas um dos três possíveis valores: `TRUE`, `FALSE` e `NA`.
 É relativamente raro encontrar vetores lógicos em seus dados brutos, mas você os criará e manipulará no decorrer de quase todas as análises.
 
 Começaremos discutindo a forma mais comum de criar vetores lógicos: com comparações numéricas.

--- a/logicals.qmd
+++ b/logicals.qmd
@@ -462,7 +462,7 @@ Nós poderíamos resolver isso adicionando um novo `if_else()`:
 if_else(x == 0, "0", if_else(x < 0, "-vo", "+vo"), "???")
 ```
 
-Isto já é um pouco difícil de ler, mas você pode imaginar como se tornaria mais difícil se você tiver mais ainda mais condições.
+Isto já é um pouco difícil de ler, mas você pode imaginar como se tornaria mais difícil se você tiver ainda mais condições.
 Ao invés disso, você deve mudar para o `dplyr::case_when()`.
 
 ### `case_when()`

--- a/logicals.qmd
+++ b/logicals.qmd
@@ -102,7 +102,7 @@ x == c(1, 2)
 ```
 
 O que está acontecendo aqui?
-Os computadores armazenam números com um número fixo de casas decimais, então não há como representar exatamente 1/49 ou `sqrt(2)` e os cálculos subsequentes serão ligeiramente errados.
+Os computadores armazenam números com um número fixo de casas decimais, então não há como representar exatamente 1/49 ou `sqrt(2)` e os cálculos subsequentes serão ligeiramente imprecisos.
 Podemos ver os valores exatos chamando `print()` com o argumento `digits`[^logicals-1]:
 
 [^logicals-1]: R normalmente chama *print* para você (e.x. `x` é um atalho para `print(x)`), mas chamando-o explicitamente é útil se você quer fornecer outros argumentos.

--- a/logicals.qmd
+++ b/logicals.qmd
@@ -28,7 +28,6 @@ Também continuaremos a extrair exemplos do conjunto de dados `dados::voos`.
 #| message: false
 
 library(tidyverse)
-library(nycflights13)
 library (dados)
 ```
 

--- a/logicals.qmd
+++ b/logicals.qmd
@@ -1,27 +1,27 @@
-# Logical vectors {#sec-logicals}
+# Vetores lógicos {#sec-logicals}
 
 ```{r}
 #| echo: false
 #| results: asis
 
 source("_common.R")
-mensagem_capitulo_sem_traducao()
+
 ```
 
-## Introduction
+## Introdução
 
-In this chapter, you'll learn tools for working with logical vectors.
-Logical vectors are the simplest type of vector because each element can only be one of three possible values: `TRUE`, `FALSE`, and `NA`.
-It's relatively rare to find logical vectors in your raw data, but you'll create and manipulate them in the course of almost every analysis.
+Neste capítulo, você aprenderá ferramentas para trabalhar com vetores lógicos.
+Vetores lógicos são a forma mais simples de vetores, pois cada elemento pode ter apenas um dos três possíveis valores:: `TRUE`, `FALSE` e `NA`.
+É relativamente raro encontrar vetores lógicos em seus dados brutos, mas você os criará e manipulará no decorrer de quase todas as análises.
 
-We'll begin by discussing the most common way of creating logical vectors: with numeric comparisons.
-Then you'll learn about how you can use Boolean algebra to combine different logical vectors, as well as some useful summaries.
-We'll finish off with `if_else()` and `case_when()`, two useful functions for making conditional changes powered by logical vectors.
+Começaremos discutindo a forma mais comum de criar vetores lógicos: com comparações numéricas.
+Em seguida, você aprenderá como usar a álgebra booleana para combinar diferentes vetores lógicos, bem como algumas sumarizações úteis.
+Terminaremos com `if_else()` e `case_when()`, duas funções úteis para fazer alterações condicionais alimentadas por vetores lógicos.
 
-### Prerequisites
+### Pré-requisitos
 
-Most of the functions you'll learn about in this chapter are provided by base R, so we don't need the tidyverse, but we'll still load it so we can use `mutate()`, `filter()`, and friends to work with data frames.
-We'll also continue to draw examples from the `nycflights13::flights` dataset.
+A maioria das funções que você aprenderá neste capítulo são fornecidas pelo R base, então não precisamos do tidyverse, mas ainda assim iremos carregá-lo para que possamos usar `mutate()`, `filter()`, e demais funções para trabalhar com *data frames*.
+Também continuaremos a extrair exemplos do conjunto de dados `dados::voos`.
 
 ```{r}
 #| label: setup
@@ -29,18 +29,19 @@ We'll also continue to draw examples from the `nycflights13::flights` dataset.
 
 library(tidyverse)
 library(nycflights13)
+library (dados)
 ```
 
-However, as we start to cover more tools, there won't always be a perfect real example.
-So we'll start making up some dummy data with `c()`:
+No entanto, à medida que começamos a cobrir mais ferramentas, nem sempre haverá um exemplo real perfeito.
+Então, começaremos a criar alguns dados fictícios com `c()`:
 
 ```{r}
 x <- c(1, 2, 3, 5, 7, 11, 13)
 x * 2
 ```
 
-This makes it easier to explain individual functions at the cost of making it harder to see how it might apply to your data problems.
-Just remember that any manipulation we do to a free-floating vector, you can do to a variable inside a data frame with `mutate()` and friends.
+Isso facilita a explicação de funções individuais, ao custo de dificultar a visualização de como elas podem se aplicar aos seus problemas de dados.
+Apenas lembre-se de que qualquer manipulação que fizermos em um vetor simples (*free-floating*), você poderá fazer em uma variável dentro de *data frame* com `mutate()` e demais funções amigas.
 
 ```{r}
 df <- tibble(x)
@@ -48,119 +49,119 @@ df |>
   mutate(y = x * 2)
 ```
 
-## Comparisons
+## Comparações
 
-A very common way to create a logical vector is via a numeric comparison with `<`, `<=`, `>`, `>=`, `!=`, and `==`.
-So far, we've mostly created logical variables transiently within `filter()` --- they are computed, used, and then thrown away.
-For example, the following filter finds all daytime departures that arrive roughly on time:
+Uma forma muito comum de criar um vetor lógico é através de uma comparação numérica usando `<`, `<=`, `>`, `>=`, `!=` e `==`.
+Até agora, criamos principalmente variáveis ​​lógicas transitoriamente dentro de `filter()` --- elas são calculadas, usadas e depois jogadas fora.
+Por exemplo, o filtro abaixo encontra todo os voos que sairam durante o dia e chegaram aproximadamente no horário:
 
 ```{r}
-flights |> 
-  filter(dep_time > 600 & dep_time < 2000 & abs(arr_delay) < 20)
+voos |> 
+  filter(horario_saida > 600 & horario_saida < 2000 & abs(atraso_chegada) < 20)
 ```
 
-It's useful to know that this is a shortcut and you can explicitly create the underlying logical variables with `mutate()`:
+É útil saber que isto é apenas um atalho e você pode explicitamente criar a variável lógica intrínseca com  `mutate()`:
 
 ```{r}
-flights |> 
+voos |> 
   mutate(
-    daytime = dep_time > 600 & dep_time < 2000,
-    approx_ontime = abs(arr_delay) < 20,
+    diurno = horario_saida > 600 & horario_saida < 2000,
+    aprox_no_horario = abs(atraso_chegada) < 20,
     .keep = "used"
   )
 ```
 
-This is particularly useful for more complicated logic because naming the intermediate steps makes it easier to both read your code and check that each step has been computed correctly.
+Isto é particularmente útil para lógicas mais complicadas, pois nomeando os passos intermediarios, se torna mais fácil tanto ler o código quanto verificar se cada passo está sendo calculado corretamente.
 
-All up, the initial filter is equivalent to:
+Com isto, o filtro inicial é equivalente a:
 
 ```{r}
 #| results: false
 
-flights |> 
+voos |> 
   mutate(
-    daytime = dep_time > 600 & dep_time < 2000,
-    approx_ontime = abs(arr_delay) < 20,
+    diurno = horario_saida > 600 & horario_saida < 2000,
+    aprox_no_horario = abs(atraso_chegada) < 20,
   ) |> 
-  filter(daytime & approx_ontime)
+  filter(diurno & aprox_no_horario)
 ```
 
-### Floating point comparison {#sec-fp-comparison}
+### Comparações com ponto-flutuante (*floating point*) {#sec-fp-comparison}
 
-Beware of using `==` with numbers.
-For example, it looks like this vector contains the numbers 1 and 2:
+Cuidado ao usar `==` com números.
+Por exemplo, parece que este vetor contém os números 1 e 2:
 
 ```{r}
 x <- c(1 / 49 * 49, sqrt(2) ^ 2)
 x
 ```
 
-But if you test them for equality, you get `FALSE`:
+Mas se você fizer um teste de igualdade, você terá `FALSE`:
 
 ```{r}
 x == c(1, 2)
 ```
 
-What's going on?
-Computers store numbers with a fixed number of decimal places so there's no way to exactly represent 1/49 or `sqrt(2)` and subsequent computations will be very slightly off.
-We can see the exact values by calling `print()` with the `digits`[^logicals-1] argument:
+O que está acontecendo aqui?
+Os computadores armazenam números com um número fixo de casas decimais, então não há como representar exatamente 1/49 ou `sqrt(2)` e os cálculos subsequentes serão ligeiramente errados.
+Podemos ver os valores exatos chamando `print()` com o argumento `digits`[^logicals-1]:
 
-[^logicals-1]: R normally calls print for you (i.e. `x` is a shortcut for `print(x)`), but calling it explicitly is useful if you want to provide other arguments.
+[^logicals-1]: R normalmente chama *print* para você (e.x. `x` é um atalho para `print(x)`), mas chamando-o explicitamente é útil se você quer fornecer outros argumentos.
 
 ```{r}
 print(x, digits = 16)
 ```
 
-You can see why R defaults to rounding these numbers; they really are very close to what you expect.
+Você pode ver porque o R arrendonda estes números por padrão: eles são realmente muito próximos ao que você espera.
 
-Now that you've seen why `==` is failing, what can you do about it?
-One option is to use `dplyr::near()` which ignores small differences:
+Agora que você viu porque `==` falhou, o que você pode fazer a respeito?
+Uma opção é usar `dplyr::near()` que ignora pequenas diferenças:
 
 ```{r}
 near(x, c(1, 2))
 ```
 
-### Missing values {#sec-na-comparison}
+### Valores faltantes (*missing values*) {#sec-na-comparison}
 
-Missing values represent the unknown so they are "contagious": almost any operation involving an unknown value will also be unknown:
+Os valores faltantes (*missing values) representam o desconhecido, portanto são "contagiosos": quase qualquer operações que envolva um valor desconhecido também será desconhecida:
 
 ```{r}
 NA > 5
 10 == NA
 ```
 
-The most confusing result is this one:
+O resultado mais confuso é este:
 
 ```{r}
 NA == NA
 ```
 
-It's easiest to understand why this is true if we artificially supply a little more context:
+É mais fácil entender porque isto é verdadeiro se nós artificialmente fornecermos um pouco mais de contexto:
 
 ```{r}
-# We don't know how old Mary is
-age_mary <- NA
+# Não sabemos a idade de Maria
+idade_maria <- NA
 
-# We don't know how old John is
-age_john <- NA
+# Não sabemos a idade de João
+idade_joao <- NA
 
-# Are Mary and John the same age?
-age_mary == age_john
-# We don't know!
+# João e Maria tem a mesma idade?
+idade_maria == idade_joao
+# Não sabemos!
 ```
 
-So if you want to find all flights where `dep_time` is missing, the following code doesn't work because `dep_time == NA` will yield `NA` for every single row, and `filter()` automatically drops missing values:
+Portanto, se você quiser encontrar todos os voos onde `horario_saida` está faltando, o código a seguir não funciona, pois `horario_saida == NA` retorna `NA` para cada linha e `filter()` ignora automaticamente valores faltantes:
 
 ```{r}
-flights |> 
-  filter(dep_time == NA)
+voos |> 
+  filter(horario_saida == NA)
 ```
 
-Instead we'll need a new tool: `is.na()`.
+Ao invés disso, vocè precisará de uma nova ferramenta: `is.na()`.
 
 ### `is.na()`
 
-`is.na(x)` works with any type of vector and returns `TRUE` for missing values and `FALSE` for everything else:
+`is.na(x)` funciona com qualquer tipo de vetor e retorna `TRUE` para valores faltantes e `FALSE` para qualquer outra coisa:
 
 ```{r}
 is.na(c(TRUE, NA, FALSE))
@@ -168,117 +169,117 @@ is.na(c(1, NA, 3))
 is.na(c("a", NA, "b"))
 ```
 
-We can use `is.na()` to find all the rows with a missing `dep_time`:
+Podemos usar `is.na()` para encontrar todos os registros com `horario_saida` faltando:
 
 ```{r}
-flights |> 
-  filter(is.na(dep_time))
+voos |> 
+  filter(is.na(horario_saida))
 ```
 
-`is.na()` can also be useful in `arrange()`.
-`arrange()` usually puts all the missing values at the end but you can override this default by first sorting by `is.na()`:
+`is.na()` também pode ser útil em `arrange()`.
+`arrange()` geralmente coloca todos os valores faltantes no final, mas você pode sobreescrever este padrão ordenando primeiro com `is.na()`:
 
 ```{r}
-flights |> 
-  filter(month == 1, day == 1) |> 
-  arrange(dep_time)
+voos |> 
+  filter(mes == 1, dia == 1) |> 
+  arrange(horario_saida)
 
-flights |> 
-  filter(month == 1, day == 1) |> 
-  arrange(desc(is.na(dep_time)), dep_time)
+voos |> 
+  filter(mes == 1, dia == 1) |> 
+  arrange(desc(is.na(horario_saida)), horario_saida)
 ```
 
-We'll come back to cover missing values in more depth in @sec-missing-values.
+Retornaremos a cobrir mais detalhes sobre valores faltantes (*missing values*) no @sec-missing-values.
 
-### Exercises
+### Exercócio
 
-1.  How does `dplyr::near()` work? Type `near` to see the source code. Is `sqrt(2)^2` near 2?
-2.  Use `mutate()`, `is.na()`, and `count()` together to describe how the missing values in `dep_time`, `sched_dep_time` and `dep_delay` are connected.
+1.  Como `dplyr::near()` funciona? Digite `near` para ver o código fonte. `sqrt(2)^2` é próximo (near) a 2?
+2.  Use `mutate()`, `is.na()` e `count()` juntos para descrever como os valores faltantes (*missing values*) em `horario_saida`, `saida_programada` e `atraso_saida` estão relacionados.
 
-## Boolean algebra
+## Algebra booleana
 
-Once you have multiple logical vectors, you can combine them together using Boolean algebra.
-In R, `&` is "and", `|` is "or", `!` is "not", and `xor()` is exclusive or[^logicals-2].
-For example, `df |> filter(!is.na(x))` finds all rows where `x` is not missing and `df |> filter(x < -10 | x > 0)` finds all rows where `x` is smaller than -10 or bigger than 0.
-@fig-bool-ops shows the complete set of Boolean operations and how they work.
+Quando você tem múltiplos vetores lógicos, você pode combiná-los usando algebra booleana.
+No R, `&` é "e", `|` é "ou", `!` é "não" e `xor()` é ou exclusivo[^logicals-2].
+Por exemplo, `df |> filter(!is.na(x))` encontra todas as linhas onde `x` está faltando e `df |> filter(x < -10 | x > 0)` encontra todas as linhas onde `x` é menor que -10 ou maior que 0.
+A @fig-bool-ops mostra o conjunto completo de operações booleanas e como elas funcionam.
 
-[^logicals-2]: That is, `xor(x, y)` is true if x is true, or y is true, but not both.
-    This is how we usually use "or" In English.
-    "Both" is not usually an acceptable answer to the question "would you like ice cream or cake?".
+[^logicals-2]: Isto é, `xor(x, y)` é verdadeiro se x for verdadeiro, ou y for verdadeiro, mas nunca ambos.
+    Isto é como usamos "ou" em Português.
+    "Ambos" geralmente não é uma resposta aceitável quando respondemos a pergunta "Você gostaria de sorvete ou bolo?".
 
 ```{r}
 #| label: fig-bool-ops
 #| echo: false
 #| out-width: NULL
 #| fig-cap: | 
-#|    The complete set of Boolean operations. `x` is the left-hand
-#|    circle, `y` is the right-hand circle, and the shaded region show 
-#|    which parts each operator selects.
+#|    O conjunto completo de operações booleanas. `x` é o círuclo da esquerda
+#|    , `y` é o círculo da direita e a região preenchida mostra 
+#|    qual parte cada operação seleciona.
 #| fig-alt: |
-#|    Six Venn diagrams, each explaining a given logical operator. The
-#|    circles (sets) in each of the Venn diagrams represent x and y. 1. y &
-#|    !x is y but none of x; x & y is the intersection of x and y; x & !y is
-#|    x but none of y; x is all of x none of y; xor(x, y) is everything
-#|    except the intersection of x and y; y is all of y and none of x; and 
-#|    x | y is everything.
+#|    Seis diagramas de Venn, como um explicando um determinado operador lógico. Os
+#|    círculos (conjunto) em cada diagrama de Venn representam x e y. 1. y &
+#|    !x é y mas nada de x; x & y é a intersecção de de x e y; x & !y é
+#|    x mas nada de y; x é tudo de x mas nada de y; xor(x, y) é tudo menos
+#|    a interseccção de x e y; y é tudo de y e nada de x; e 
+#|    x | y é tudo.
 knitr::include_graphics("diagrams/transform.png", dpi = 270)
 ```
 
-As well as `&` and `|`, R also has `&&` and `||`.
-Don't use them in dplyr functions!
-These are called short-circuiting operators and only ever return a single `TRUE` or `FALSE`.
-They're important for programming, not data science.
+Além de `&` e `|`, o R também possui `&&` e `||`.
+Não os use em funções dplyr!
+Eles são chamados de operadores de curto-circuito e retornam sempre apenas um único `TRUE` ou `FALSE`.
+Eles são importantes na programação, não em ciência de dados.
 
-### Missing values {#sec-na-boolean}
+### Valore faltantes (*missing values*) {#sec-na-boolean}
 
-The rules for missing values in Boolean algebra are a little tricky to explain because they seem inconsistent at first glance:
+As regras para valores ausentes na álgebra booleana são um pouco complicadas de explicar porque parecem inconsistentes à primeira vista:
 
 ```{r}
 df <- tibble(x = c(TRUE, FALSE, NA))
 
 df |> 
   mutate(
-    and = x & NA,
-    or = x | NA
+    e = x & NA,
+    ou = x | NA
   )
 ```
 
-To understand what's going on, think about `NA | TRUE` (`NA` or `TRUE`).
-A missing value in a logical vector means that the value could either be `TRUE` or `FALSE`.
-`TRUE | TRUE` and `FALSE | TRUE` are both `TRUE` because at least one of them is `TRUE`.
-`NA | TRUE` must also be `TRUE` because `NA` can either be `TRUE` or `FALSE`.
-However, `NA | FALSE` is `NA` because we don't know if `NA` is `TRUE` or `FALSE`.
-Similar reasoning applies with `NA & FALSE`.
+Para entender o que está acontecendo aqui, pense em `NA | TRUE` (`NA` ou `TRUE`).
+Um valor faltante (*missing value*) em um vetor lógico significa que o valor poderia ser `TRUE` ou `FALSE`.
+`TRUE | TRUE` e `FALSE | TRUE` são ambos `TRUE` pois ao menos um dors termos é `TRUE`.
+`NA | TRUE` também deve ser `TRUE` pois `NA` pode ser `TRUE` ou `FALSE`.
+Ententando, `NA | FALSE` é `NA` pois não sabemos se `NA` é `TRUE` ou `FALSE`.
+O mesmo se aplica com `NA & FALSE`.
 
-### Order of operations
+### Order das operações
 
-Note that the order of operations doesn't work like English.
-Take the following code that finds all flights that departed in November or December:
+Observe que a ordem das operações não funcionam como em Português.
+Veja o seguinte código que encotnra todos os voos que saíram em Novembro ou Dezembro:
 
 ```{r}
 #| eval: false
 
-flights |> 
-   filter(month == 11 | month == 12)
+voos |> 
+   filter(mes == 11 | mes == 12)
 ```
 
-You might be tempted to write it like you'd say in English: "Find all flights that departed in November or December.":
+Você pode estar tentado a escrevê-lo da forma que falaria em Português: "Encontre todos os voos que saíram em Novemebro e Dezembro.":
 
 ```{r}
-flights |> 
-   filter(month == 11 | 12)
+voos |> 
+   filter(mes == 11 | 12)
 ```
 
-This code doesn't error but it also doesn't seem to have worked.
-What's going on?
-Here, R first evaluates `month == 11` creating a logical vector, which we call `nov`.
-It computes `nov | 12`.
-When you use a number with a logical operator it converts everything apart from 0 to `TRUE`, so this is equivalent to `nov | TRUE` which will always be `TRUE`, so every row will be selected:
+Este código não gera erro, mas também não parece ter funcionado.
+O que acontece aqui?
+Neste caso, o R calcula `mes == 11` criando um vetor lógico, o qual chamaremos de `nov`.
+Então calcula `nov | 12`.
+Quando usamos um número com um operador lógico, ele converte tudo exceto 0 para `TRUE`, o que é equivalente a `nov | TRUE` o que é sempre `TRUE`, então cada linha será selecionada:
 
 ```{r}
-flights |> 
+voos |> 
   mutate(
-    nov = month == 11,
+    nov = mes == 11,
     final = nov | 12,
     .keep = "used"
   )
@@ -286,168 +287,168 @@ flights |>
 
 ### `%in%`
 
-An easy way to avoid the problem of getting your `==`s and `|`s in the right order is to use `%in%`.
-`x %in% y` returns a logical vector the same length as `x` that is `TRUE` whenever a value in `x` is anywhere in `y` .
+Um jeito fácil de evitar o problema de colocar `==`s e `|`s na order correta é usar `%in%`.
+`x %in% y` retorna um vetor lógico de mesmo tamanho que `x` que é `TRUE` sempre que um valor em `x` está em qualquer lugar em `y` .
 
 ```{r}
 1:12 %in% c(1, 5, 11)
 letters[1:10] %in% c("a", "e", "i", "o", "u")
 ```
 
-So to find all flights in November and December we could write:
+Portanto, para encontrar todos os voos de Novembro e Dezembro, poderíamos escrever:
 
 ```{r}
 #| eval: false
 
-flights |> 
-  filter(month %in% c(11, 12))
+voos |> 
+  filter(mes %in% c(11, 12))
 ```
 
-Note that `%in%` obeys different rules for `NA` to `==`, as `NA %in% NA` is `TRUE`.
+Note que `%in%` possui diferentes regras do `NA` para `==`, uma vez que `NA %in% NA` é `TRUE`.
 
 ```{r}
 c(1, 2, NA) == NA
 c(1, 2, NA) %in% NA
 ```
 
-This can make for a useful shortcut:
+Isto pode ser um atalho útil:
 
 ```{r}
-flights |> 
-  filter(dep_time %in% c(NA, 0800))
+voos |> 
+  filter(horario_saida %in% c(NA, 0800))
 ```
 
-### Exercises
+### Exercícios
 
-1.  Find all flights where `arr_delay` is missing but `dep_delay` is not. Find all flights where neither `arr_time` nor `sched_arr_time` are missing, but `arr_delay` is.
-2.  How many flights have a missing `dep_time`? What other variables are missing in these rows? What might these rows represent?
-3.  Assuming that a missing `dep_time` implies that a flight is cancelled, look at the number of cancelled flights per day. Is there a pattern? Is there a connection between the proportion of cancelled flights and the average delay of non-cancelled flights?
+1.  Encontre todos os voos onde `atraso_chegada` está faltando (*missing*), mas `atraso_saida` não. Encontre todos os voos onde nem `horario_chegada` ou `chegada_prevista` estão faltando, mas `atraso_chegada` está.
+2.  Quantos voos possuem `horiria_saida` faltando? Quais outras variáveis possuem valores faltantes nestes registros? O que podem representar estas linhas?
+3.  Assumindo que um valor faltante em `horario_saida` implica em um voo cancelado, olhe o número de voos cancelados por dia. Há algum padrão? Há alguma relação entre a proporção de voos cancelados e a média de atraso dos voos não cancelados?
 
-## Summaries {#sec-logical-summaries}
+## Sumarização {#sec-logical-summaries}
 
-The following sections describe some useful techniques for summarizing logical vectors.
-As well as functions that only work specifically with logical vectors, you can also use functions that work with numeric vectors.
+As seções a seguir descrevem técnicas úteis para sumarização de vetores lógicos.
+Assim como funções que trabalham especificamente com vetores lógicos, você também pode usar funções que trabalham com vetores numéricos.
 
-### Logical summaries
+### Sumarizações lógicas
 
-There are two main logical summaries: `any()` and `all()`.
-`any(x)` is the equivalent of `|`; it'll return `TRUE` if there are any `TRUE`'s in `x`.
-`all(x)` is equivalent of `&`; it'll return `TRUE` only if all values of `x` are `TRUE`'s.
-Like all summary functions, they'll return `NA` if there are any missing values present, and as usual you can make the missing values go away with `na.rm = TRUE`.
+Existem dois sumarizadores lógicos: `any()` e `all()`.
+`any(x)` é o equivalente ao `|`; retornará `TRUE` se houver algum `TRUE` em `x`.
+`all(x)` é o equivalente ao `&`; retornará `TRUE` somente se todos os valores de `x` forem `TRUE`.
+Assim como todas as funções de sumarização, elas retornarão `NA` se houver qualquer valor faltante (*missing value*) presente, e como de costume, você pode não considerá-los usando `na.rm = TRUE`.
 
-For example, we could use `all()` and `any()` to find out if every flight was delayed on departure by at most an hour or if any flights were delayed on arrival by five hours or more.
+Por exemplo, poderíamos usar `all()` e `any()` para encontrar se todos os voos que atrasaram no máximo uma hora na saída ou se algum voo atrasou na chegada cinco horas ou mais.
 And using `group_by()` allows us to do that by day:
 
 ```{r}
-flights |> 
-  group_by(year, month, day) |> 
+voos |> 
+  group_by(ano, mes, dia) |> 
   summarize(
-    all_delayed = all(dep_delay <= 60, na.rm = TRUE),
-    any_long_delay = any(arr_delay >= 300, na.rm = TRUE),
+    todos_atrasados = all(atraso_saida <= 60, na.rm = TRUE),
+    algum_atraso_longo = any(atraso_chegada >= 300, na.rm = TRUE),
     .groups = "drop"
   )
 ```
 
-In most cases, however, `any()` and `all()` are a little too crude, and it would be nice to be able to get a little more detail about how many values are `TRUE` or `FALSE`.
-That leads us to the numeric summaries.
+Na maioria dos casos, entretanto, `any()` e `all()` são um tanto grosseiros, e seria bom poder obter mais detalhes sobre os valores `TRUE` ou `FALSE`.
+Isso nos leval aos sumarizadores numéricos.
 
-### Numeric summaries of logical vectors {#sec-numeric-summaries-of-logicals}
+### Sumarizações numéricas de vetores lógicos {#sec-numeric-summaries-of-logicals}
 
-When you use a logical vector in a numeric context, `TRUE` becomes 1 and `FALSE` becomes 0.
-This makes `sum()` and `mean()` very useful with logical vectors because `sum(x)` gives the number of `TRUE`s and `mean(x)` gives the proportion of `TRUE`s (because `mean()` is just `sum()` divided by `length()`.
+Quando você usa um vetor lógico em um contexto numérico, `TRUE` se torna 1 e `FALSE` se torna 0.
+Isto torna `sum()` e `mean()` muito úteis com vetores lógicos, pois `sum(x)` retorna o número de `TRUE`s e `mean(x)` retorna a proporção de `TRUE`s (pois `mean()` é apenas `sum()` dividido por`length()`).
 
-That, for example, allows us to see the proportion of flights that were delayed on departure by at most an hour and the number of flights that were delayed on arrival by five hours or more:
+Isto, por exemplo, nos permite ver a proporção de voos que tiveram atraso na saída em até uma hora e o número de voos que chegaram atrasados em cinco horas ou mais.:
 
 ```{r}
-flights |> 
-  group_by(year, month, day) |> 
+voos |> 
+  group_by(ano, mes, dia) |> 
   summarize(
-    all_delayed = mean(dep_delay <= 60, na.rm = TRUE),
-    any_long_delay = sum(arr_delay >= 300, na.rm = TRUE),
+    todos_atrasados = mean(atraso_saida <= 60, na.rm = TRUE),
+    algum_atraso_longo = sum(atraso_chegada >= 300, na.rm = TRUE),
     .groups = "drop"
   )
 ```
 
-### Logical subsetting
+### Subconjunto (*subsetting*) lógico
 
-There's one final use for logical vectors in summaries: you can use a logical vector to filter a single variable to a subset of interest.
-This makes use of the base `[` (pronounced subset) operator, which you'll learn more about in @sec-subset-many.
+Existe ainda um último uso de vetores lógicos em sumarizações: você pode usar um vetor lógico para filtrar uma única variável em um subconjunto (*subset*) de interesse.
+Isto faz uso do operador do R base `[` (se pronuncia *subset*), o qual você aprenderá mais na @sec-subset-many.
 
-Imagine we wanted to look at the average delay just for flights that were actually delayed.
-One way to do so would be to first filter the flights and then calculate the average delay:
+Imagine que gostaríamos de encontrar a média de atraso somente de voos que realmente estiveram atrasados.
+Uma forma de fazê-lo seria primeiro filtrar os voos e depois calcular a média de atraso:
 
 ```{r}
-flights |> 
-  filter(arr_delay > 0) |> 
-  group_by(year, month, day) |> 
+voos |> 
+  filter(atraso_chegada > 0) |> 
+  group_by(ano, mes, dia) |> 
   summarize(
-    behind = mean(arr_delay),
+    atraso_medio = mean(atraso_chegada),
     n = n(),
     .groups = "drop"
   )
 ```
 
-This works, but what if we wanted to also compute the average delay for flights that arrived early?
-We'd need to perform a separate filter step, and then figure out how to combine the two data frames together[^logicals-3].
-Instead you could use `[` to perform an inline filtering: `arr_delay[arr_delay > 0]` will yield only the positive arrival delays.
+Isto funciona, mas e se você quisesse calcular o atraso médio também para voos que chegaram antecipadamente?
+Precisaríamos fazer um passo extre de filtro e então combinar os dois *data frames*[^logicals-3].
+Ao invés disso, você poderia usar `[` para executar um filtro em linha (*inline*): `atraso_chegada[atraso_chegada > 0]` irá retornar apenas os atrasos positivos na chegada.
 
-[^logicals-3]: We'll cover this in @sec-joins.
+[^logicals-3]: Iremos cobrir isto na @sec-joins.
 
 This leads to:
 
 ```{r}
-flights |> 
-  group_by(year, month, day) |> 
+voos |> 
+  group_by(ano, mes, dia) |> 
   summarize(
-    behind = mean(arr_delay[arr_delay > 0], na.rm = TRUE),
-    ahead = mean(arr_delay[arr_delay < 0], na.rm = TRUE),
+    atrasado = mean(atraso_chegada[atraso_chegada > 0], na.rm = TRUE),
+    antecipado = mean(atraso_chegada[atraso_chegada < 0], na.rm = TRUE),
     n = n(),
     .groups = "drop"
   )
 ```
 
-Also note the difference in the group size: in the first chunk `n()` gives the number of delayed flights per day; in the second, `n()` gives the total number of flights.
+Observe também a diferença no tamanho do grupo: no primeiro segmento `n()` tem o número de voos em atraso por dia, no segundo, `n()` retorna o número total de voos.
 
 ### Exercises
 
-1.  What will `sum(is.na(x))` tell you? How about `mean(is.na(x))`?
-2.  What does `prod()` return when applied to a logical vector? What logical summary function is it equivalent to? What does `min()` return when applied to a logical vector? What logical summary function is it equivalent to? Read the documentation and perform a few experiments.
+1.  Que `sum(is.na(x))` diz a você? E `mean(is.na(x))`?
+2.  O que `prod()` returna quando aploicada a um vetor lógico? Qual função de sumarização lógica é equivalente? O que `min()` returna quando aplicada a um vetor lógico? Qual função de sumarização lógica é equivalente? Leia a documentação e efetue alguns experimentos.
 
-## Conditional transformations
+## Transformações condicionais
 
-One of the most powerful features of logical vectors are their use for conditional transformations, i.e. doing one thing for condition x, and something different for condition y.
-There are two important tools for this: `if_else()` and `case_when()`.
+Uma das características mais poderosas de vetores lógico é seu uso em transformações condicionais, i.x. fazer alguma coisa em uma condição x, e alguma outra coisa diferente para a y.
+Existem duas ferramentas importantes para isso: `if_else()` e `case_when()`.
 
 ### `if_else()`
 
-If you want to use one value when a condition is `TRUE` and another value when it's `FALSE`, you can use `dplyr::if_else()`[^logicals-4].
-You'll always use the first three argument of `if_else()`. The first argument, `condition`, is a logical vector, the second, `true`, gives the output when the condition is true, and the third, `false`, gives the output if the condition is false.
+Se você quiser usar um valor para quando a condição é `TRUE` e outro valor para quando a condição é `FALSE`, você pode usar `dplyr::if_else()`[^logicals-4].
+Você sempre usará os primeiros três argumentos de `if_else()`. O primeiro, `condition`, é um vetor lógico, o segundo, `true`, gera uma saída quando a condiçção é verdadeira (*true*) , e o terceiro, `false`, gera uma saída quando a condição é falsa (*false*).
 
-[^logicals-4]: dplyr's `if_else()` is very similar to base R's `ifelse()`.
-    There are two main advantages of `if_else()`over `ifelse()`: you can choose what should happen to missing values, and `if_else()` is much more likely to give you a meaningful error if your variables have incompatible types.
+[^logicals-4]: A função `if_else()` do dplyr é muito similar a `ifelse()` do R base .
+    Existem duas vantagens principais do `if_else()` sobre `ifelse()`: você pode escolhar o que acontece com valor faltantes (*minssing values*) e `if_else()` te retorna erros com mais sentido se sua variável possuir tipos incompatíveis.
 
-Let's begin with a simple example of labeling a numeric vector as either "+ve" (positive) or "-ve" (negative):
+Vamos começar com um simples exemplo rotulando um vetor numérico como "+vo" (positivo) ou "-vo" (negativo):
 
 ```{r}
 x <- c(-3:3, NA)
-if_else(x > 0, "+ve", "-ve")
+if_else(x > 0, "+vo", "-vo")
 ```
 
-There's an optional fourth argument, `missing` which will be used if the input is `NA`:
+Há um quarto argumento opcional, `missing` o qual pode ser usado se a entrada for um valor `NA`:
 
 ```{r}
-if_else(x > 0, "+ve", "-ve", "???")
+if_else(x > 0, "+vo", "-vo", "???")
 ```
 
-You can also use vectors for the the `true` and `false` arguments.
-For example, this allows us to create a minimal implementation of `abs()`:
+Você também usar vetores para os argumentos `true` e `false`.
+Por exemplo, isto nos permite criar uma implmentação mínima de `abs()`:
 
 ```{r}
 if_else(x < 0, -x, x)
 ```
 
-So far all the arguments have used the same vectors, but you can of course mix and match.
-For example, you could implement a simple version of `coalesce()` like this:
+Até agora, todos os argumentos usaram os mesmos vetores, mas você pode misturar e combinar isso.
+Por exemplo, você pode implementar uma versão simples de `coalesce()` desta forma:
 
 ```{r}
 x1 <- c(NA, 1, 2, NA)
@@ -455,90 +456,90 @@ y1 <- c(3, NA, 4, 6)
 if_else(is.na(x1), y1, x1)
 ```
 
-You might have noticed a small infelicity in our labeling example above: zero is neither positive nor negative.
-We could resolve this by adding an additional `if_else()`:
+Você pode notar uma pequena infelicidade em nosso exemplo de rótulo acima: zero não é nem positivo nem negativo.
+Nós poderíamos resolver isso adicionando um novo `if_else()`:
 
 ```{r}
-if_else(x == 0, "0", if_else(x < 0, "-ve", "+ve"), "???")
+if_else(x == 0, "0", if_else(x < 0, "-vo", "+vo"), "???")
 ```
 
-This is already a little hard to read, and you can imagine it would only get harder if you have more conditions.
-Instead, you can switch to `dplyr::case_when()`.
+Isto já é um pouco difícil de ler, mas você pode imaginar como se tornaria mais difícil se você tiver mais ainda mais condições.
+Ao invés disso, você deve mudar para o `dplyr::case_when()`.
 
 ### `case_when()`
 
-dplyr's `case_when()` is inspired by SQL's `CASE` statement and provides a flexible way of performing different computations for different conditions.
-It has a special syntax that unfortunately looks like nothing else you'll use in the tidyverse.
-It takes pairs that look like `condition ~ output`.
-`condition` must be a logical vector; when it's `TRUE`, `output` will be used.
+O `case_when()` do pacote dplyr é inspirado pela declaração `CASE` do SQL e oferece uma forma flexível de efetuar diferentes cálculos para diferentes condições.
+Infelizmente, ele tem uma sintaxe que não se parece com nada que você usará no pacote tidyverse.
+Ele recebe pares que se parecem com `condição ~ saída`.
+`condição` deve ser um vetor lógico; quando for `TRUE`, `saída` será usada.
 
-This means we could recreate our previous nested `if_else()` as follows:
+Isto significa que poderíamos recriar nos `if_else()` aninhado dest forma:
 
 ```{r}
 x <- c(-3:3, NA)
 case_when(
   x == 0   ~ "0",
-  x < 0    ~ "-ve", 
-  x > 0    ~ "+ve",
+  x < 0    ~ "-vo", 
+  x > 0    ~ "+vo",
   is.na(x) ~ "???"
 )
 ```
 
-This is more code, but it's also more explicit.
+O código é maior, mas também é mais explícito.
 
-To explain how `case_when()` works, let's explore some simpler cases.
-If none of the cases match, the output gets an `NA`:
+Para explicar com `case_when()` funciona, vamos explorar mais alguns casos mais simples.
+Se nenhum dos casos correponder, a saída será `NA`:
 
 ```{r}
 case_when(
-  x < 0 ~ "-ve",
-  x > 0 ~ "+ve"
+  x < 0 ~ "-vo",
+  x > 0 ~ "+vo"
 )
 ```
 
-Use `.default` if you want to create a "default"/catch all value:
+Use `.default` se você quiser gerar um "padrão"/pega todos valores:
 
 ```{r}
 case_when(
-  x < 0 ~ "-ve",
-  x > 0 ~ "+ve",
+  x < 0 ~ "-vo",
+  x > 0 ~ "+vo",
   .default = "???"
 )
 ```
 
-And note that if multiple conditions match, only the first will be used:
+E observe que se várias condições corresponderem, apenas a primeira será usada:
 
 ```{r}
 case_when(
-  x > 0 ~ "+ve",
-  x > 2 ~ "big"
+  x > 0 ~ "+vo",
+  x > 2 ~ "grande"
 )
 ```
 
-Just like with `if_else()` you can use variables on both sides of the `~` and you can mix and match variables as needed for your problem.
-For example, we could use `case_when()` to provide some human readable labels for the arrival delay:
+Assim como com `if_else()` você pode usar variáveis ​​em ambos os lados do `~` e pode misturar e combinar variáveis ​​conforme necessário para o seu problema.
+Por exemplo, poderíamos usar `case_when()` para fornecer alguns rótulos legíveis para o atraso de chegada:
 
 ```{r}
-flights |> 
+voos |> 
   mutate(
     status = case_when(
-      is.na(arr_delay)      ~ "cancelled",
-      arr_delay < -30       ~ "very early",
-      arr_delay < -15       ~ "early",
-      abs(arr_delay) <= 15  ~ "on time",
-      arr_delay < 60        ~ "late",
-      arr_delay < Inf       ~ "very late",
+      is.na(atraso_chegada)      ~ "cancelado",
+      atraso_chegada < -30       ~ "muito antecipado",
+      atraso_chegada < -15       ~ "antecipado",
+      abs(atraso_chegada) <= 15  ~ "no horario",
+      atraso_chegada < 60        ~ "atrasado",
+      atraso_chegada < Inf       ~ "muito atrasdo",
     ),
     .keep = "used"
   )
 ```
 
-Be wary when writing this sort of complex `case_when()` statement; my first two attempts used a mix of `<` and `>` and I kept accidentally creating overlapping conditions.
+Tenha cuidado ao escrever esse tipo de instrução `case_when()` complexa; minhas duas primeiras tentativas usaram uma mistura de `<` e `>` e continuei criando acidentalmente condições sobrepostas.
 
-### Compatible types
+### Tipos compatíveis
 
-Note that both `if_else()` and `case_when()` require **compatible** types in the output.
-If they're not compatible, you'll see errors like this:
+Observe que `if_else()` e `case_when()` requerem tipos **compatíveis** na saída.
+Se eles não forem compatíveis, você verá erros como este:
 
 ```{r}
 #| error: true
@@ -551,35 +552,35 @@ case_when(
 )
 ```
 
-Overall, relatively few types are compatible, because automatically converting one type of vector to another is a common source of errors.
-Here are the most important cases that are compatible:
+No geral, relativamente poucos tipos são compatíveis, porque a conversão automática de um tipo de vetor em outro é uma fonte comum de erros.
+Aqui estão os casos mais importantes que são compatíveis:
 
--   Numeric and logical vectors are compatible, as we discussed in @sec-numeric-summaries-of-logicals.
--   Strings and factors (@sec-factors) are compatible, because you can think of a factor as a string with a restricted set of values.
--   Dates and date-times, which we'll discuss in @sec-dates-and-times, are compatible because you can think of a date as a special case of date-time.
--   `NA`, which is technically a logical vector, is compatible with everything because every vector has some way of representing a missing value.
+-   Vetores numéricos e lógicos são compatíveis, conforme discutimos na @sec-numeric-summaries-of-logicals.
+-   Strings e fatores (@sec-factors) são compatíveis, porque você pode pensar em um fator como uma string com um conjunto restrito de valores.
+-   Datas e datas e horas, que discutiremos no @sec-dates-and-times, são compatíveis porque você pode pensar em uma data (*date*) como um caso especial de data_hora (*datetime*).
+-   `NA`, que é tecnicamente um vetor lógico, é compatível com tudo porque todo vetor tem alguma forma de representar um valor faltante (*missing value*).
 
-We don't expect you to memorize these rules, but they should become second nature over time because they are applied consistently throughout the tidyverse.
+Não esperamos que você memorize essas regras, mas elas devem se tornar naturais com o tempo, porque são aplicadas de forma consistente em todo o tidyverse.
 
-### Exercises
+### Exercícios
 
-1.  A number is even if it's divisible by two, which in R you can find out with `x %% 2 == 0`.
-    Use this fact and `if_else()` to determine whether each number between 0 and 20 is even or odd.
+1.  Um número é par se for divisível por dois, o que, no R, você pode descobrir com `x %% 2 == 0`.
+    Use este fato e `if_else()` para determinar se cada número entre 0 e 20 é par ou ímpar.
 
-2.  Given a vector of days like `x <- c("Monday", "Saturday", "Wednesday")`, use an `ifelse()` statement to label them as weekends or weekdays.
+2.  Dado um vetor de dias como `x <- c("Segunda-feira", "Sábado", "Quarta-feira")`, use uma instrução `ifelse()` para rotulá-los como fins de semana ou dias de semana.
 
-3.  Use `ifelse()` to compute the absolute value of a numeric vector called `x`.
+3.  Use `ifelse()` para calcular o valor absoluto de um vetor numérico chamado `x`.
 
-4.  Write a `case_when()` statement that uses the `month` and `day` columns from `flights` to label a selection of important US holidays (e.g., New Years Day, 4th of July, Thanksgiving, and Christmas).
-    First create a logical column that is either `TRUE` or `FALSE`, and then create a character column that either gives the name of the holiday or is `NA`.
+4.  Escreva uma declaração `case_when()` que usa as colunas `mes` e `dia` de `voos` para rotular um conjunto de feriados importante dos Estados Unidos (e.g., Dia de Ano Novo, 4 de Julho, Dia de Ação de Graças e Natal).
+    Primeiro crie uma coluna lógica `TRUE` ou `FALSE`, e então uma coluna texto (*character*) que tenha o nome do feriado ou `NA`.
 
-## Summary
+## Resumo
 
-The definition of a logical vector is simple because each value must be either `TRUE`, `FALSE`, or `NA`.
-But logical vectors provide a huge amount of power.
-In this chapter, you learned how to create logical vectors with `>`, `<`, `<=`, `>=`, `==`, `!=`, and `is.na()`, how to combine them with `!`, `&`, and `|`, and how to summarize them with `any()`, `all()`, `sum()`, and `mean()`.
-You also learned the powerful `if_else()` and `case_when()` functions that allow you to return values depending on the value of a logical vector.
+A definição de vetor lógico é simples pois seu valor é `TRUE`, `FALSE` ou `NA`.
+Mas os vetores lógicos oferecem grande poder.
+Neste capítulo, você aprendeu a criar vetores lógicos com `>`, `<`, `<=`, `>=`, `==`, `!=` e `is.na()`, como combiná-los com `!`, `&` e `|`, e como sumarizá-los com `any()`, `all()`, `sum()` e `mean()`.
+Você também aprendeu as funções poderosas `if_else()` e `case_when()` que permitem você retornar valores dependendo do valor de um vetor lógico.
 
-We'll see logical vectors again and again in the following chapters.
-For example in @sec-strings you'll learn about `str_detect(x, pattern)` which returns a logical vector that's `TRUE` for the elements of `x` that match the `pattern`, and in @sec-dates-and-times you'll create logical vectors from the comparison of dates and times.
-But for now, we're going to move onto the next most important type of vector: numeric vectors.
+Veremos vetores lógicos cada vez mais nos próximos capítulos.
+Por exemplo, no @sec-strings você vai aprender sobre `str_detect(x, pattern)` que retorna um vetor lógico que será `TRUE` para elementos de `x` que correnpondem ao `pattern` (padrão), e no @sec-dates-and-times você irá criar vetores lógicos a partir de comparações de datas e horários.
+Por ora, iremos para o próximo mais importante tipo de vetores: vetores numéricos.

--- a/logicals.qmd
+++ b/logicals.qmd
@@ -211,12 +211,12 @@ A @fig-bool-ops mostra o conjunto completo de operações booleanas e como elas 
 #| echo: false
 #| out-width: NULL
 #| fig-cap: | 
-#|    O conjunto completo de operações booleanas. `x` é o círuclo da esquerda
+#|    O conjunto completo de operações booleanas. `x` é o círculo da esquerda
 #|    , `y` é o círculo da direita e a região preenchida mostra 
 #|    qual parte cada operação seleciona.
 #| fig-alt: |
-#|    Seis diagramas de Venn, como um explicando um determinado operador lógico. Os
-#|    círculos (conjunto) em cada diagrama de Venn representam x e y. 1. y &
+#|    Seis diagramas de Venn, cada um explicando um determinado operador lógico. Os
+#|    círculos (conjuntos) em cada diagrama de Venn representam x e y. 1. y &
 #|    !x é y mas nada de x; x & y é a intersecção de de x e y; x & !y é
 #|    x mas nada de y; x é tudo de x mas nada de y; xor(x, y) é tudo menos
 #|    a interseccção de x e y; y é tudo de y e nada de x; e 
@@ -253,7 +253,7 @@ O mesmo se aplica com `NA & FALSE`.
 ### Order das operações
 
 Observe que a ordem das operações não funcionam como em Português.
-Veja o seguinte código que encotnra todos os voos que saíram em Novembro ou Dezembro:
+Veja o seguinte código que encontra todos os voos que saíram em novembro ou dezembro:
 
 ```{r}
 #| eval: false
@@ -294,7 +294,7 @@ Um jeito fácil de evitar o problema de colocar `==`s e `|`s na order correta é
 letters[1:10] %in% c("a", "e", "i", "o", "u")
 ```
 
-Portanto, para encontrar todos os voos de Novembro e Dezembro, poderíamos escrever:
+Portanto, para encontrar todos os voos de novembro e dezembro, poderíamos escrever:
 
 ```{r}
 #| eval: false
@@ -319,7 +319,7 @@ voos |>
 
 ### Exercícios
 
-1.  Encontre todos os voos onde `atraso_chegada` está faltando (*missing*), mas `atraso_saida` não. Encontre todos os voos onde nem `horario_chegada` ou `chegada_prevista` estão faltando, mas `atraso_chegada` está.
+1.  Encontre todos os voos em que `atraso_chegada` está faltando (*missing*), mas `atraso_saida` não. Encontre todos os voos em que nem `horario_chegada` ou `chegada_prevista` estão faltando, mas `atraso_chegada` está.
 2.  Quantos voos possuem `horario_saida` faltando? Quais outras variáveis possuem valores faltantes nestes registros? O que podem representar estas linhas?
 3.  Assumindo que um valor faltante em `horario_saida` implica em um voo cancelado, olhe o número de voos cancelados por dia. Há algum padrão? Há alguma relação entre a proporção de voos cancelados e a média de atraso dos voos não cancelados?
 
@@ -335,7 +335,7 @@ Existem dois sumarizadores lógicos: `any()` e `all()`.
 `all(x)` é o equivalente ao `&`; retornará `TRUE` somente se todos os valores de `x` forem `TRUE`.
 Assim como todas as funções de sumarização, elas retornarão `NA` se houver qualquer valor faltante (*missing value*) presente, e como de costume, você pode não considerá-los usando `na.rm = TRUE`.
 
-Por exemplo, poderíamos usar `all()` e `any()` para encontrar se todos os voos que atrasaram no máximo uma hora na saída ou se algum voo atrasou na chegada cinco horas ou mais.
+Por exemplo, poderíamos usar `all()` e `any()` para descobrir se todos os voos foram atrasados na partida por no máximo uma hora ou se algum voo atrasou na chegada por cinco horas ou mais.
 And using `group_by()` allows us to do that by day:
 
 ```{r}
@@ -349,14 +349,14 @@ voos |>
 ```
 
 Na maioria dos casos, entretanto, `any()` e `all()` são um tanto grosseiros, e seria bom poder obter mais detalhes sobre os valores `TRUE` ou `FALSE`.
-Isso nos leval aos sumarizadores numéricos.
+Isso nos leva aos sumarizadores numéricos.
 
 ### Sumarizações numéricas de vetores lógicos {#sec-numeric-summaries-of-logicals}
 
 Quando você usa um vetor lógico em um contexto numérico, `TRUE` se torna 1 e `FALSE` se torna 0.
 Isto torna `sum()` e `mean()` muito úteis com vetores lógicos, pois `sum(x)` retorna o número de `TRUE`s e `mean(x)` retorna a proporção de `TRUE`s (pois `mean()` é apenas `sum()` dividido por`length()`).
 
-Isto, por exemplo, nos permite ver a proporção de voos que tiveram atraso na saída em até uma hora e o número de voos que chegaram atrasados em cinco horas ou mais.:
+Isto, por exemplo, nos permite ver a proporção de voos que tiveram atraso na saída em até uma hora e o número de voos que chegaram atrasados em cinco horas ou mais:
 
 ```{r}
 voos |> 
@@ -388,12 +388,12 @@ voos |>
 ```
 
 Isto funciona, mas e se você quisesse calcular o atraso médio também para voos que chegaram antecipadamente?
-Precisaríamos fazer um passo extre de filtro e então combinar os dois *data frames*[^logicals-3].
+Precisaríamos fazer um passo extra de filtro e então combinar os dois *data frames*[^logicals-3].
 Ao invés disso, você poderia usar `[` para executar um filtro em linha (*inline*): `atraso_chegada[atraso_chegada > 0]` irá retornar apenas os atrasos positivos na chegada.
 
 [^logicals-3]: Iremos cobrir isto na @sec-joins.
 
-This leads to:
+Isso leva a:
 
 ```{r}
 voos |> 
@@ -410,21 +410,21 @@ Observe também a diferença no tamanho do grupo: no primeiro segmento `n()` tem
 
 ### Exercises
 
-1.  Que `sum(is.na(x))` diz a você? E `mean(is.na(x))`?
-2.  O que `prod()` returna quando aploicada a um vetor lógico? Qual função de sumarização lógica é equivalente? O que `min()` returna quando aplicada a um vetor lógico? Qual função de sumarização lógica é equivalente? Leia a documentação e efetue alguns experimentos.
+1.  O que `sum(is.na(x))` retorna? E `mean(is.na(x))`?
+2.  O que `prod()` retorna quando aplicada a um vetor lógico? Qual função de sumarização lógica é equivalente? O que `min()` retorna quando aplicada a um vetor lógico? Qual função de sumarização lógica é equivalente? Leia a documentação e efetue alguns experimentos.
 
 ## Transformações condicionais
 
-Uma das características mais poderosas de vetores lógico é seu uso em transformações condicionais, i.x. fazer alguma coisa em uma condição x, e alguma outra coisa diferente para a y.
+Uma das características mais poderosas de vetores lógico é seu uso em transformações condicionais, i.e. fazer alguma coisa em uma condição x, e alguma outra coisa diferente para a y.
 Existem duas ferramentas importantes para isso: `if_else()` e `case_when()`.
 
 ### `if_else()`
 
 Se você quiser usar um valor para quando a condição é `TRUE` e outro valor para quando a condição é `FALSE`, você pode usar `dplyr::if_else()`[^logicals-4].
-Você sempre usará os primeiros três argumentos de `if_else()`. O primeiro, `condition`, é um vetor lógico, o segundo, `true`, gera uma saída quando a condiçção é verdadeira (*true*) , e o terceiro, `false`, gera uma saída quando a condição é falsa (*false*).
+Você sempre usará os primeiros três argumentos de `if_else()`. O primeiro, `condition`, é um vetor lógico, o segundo, `true`, gera uma saída quando a condição é verdadeira (*true*), e o terceiro, `false`, gera uma saída quando a condição é falsa (*false*).
 
 [^logicals-4]: A função `if_else()` do dplyr é muito similar a `ifelse()` do R base .
-    Existem duas vantagens principais do `if_else()` sobre `ifelse()`: você pode escolhar o que acontece com valor faltantes (*minssing values*) e `if_else()` te retorna erros com mais sentido se sua variável possuir tipos incompatíveis.
+    Existem duas vantagens principais do `if_else()` sobre `ifelse()`: você pode escolher o que acontece com valor faltantes (*minssing values*) e `if_else()` te retorna erros com mais sentido se sua variável possuir tipos incompatíveis.
 
 Vamos começar com um simples exemplo rotulando um vetor numérico como "+vo" (positivo) ou "-vo" (negativo):
 

--- a/logicals.qmd
+++ b/logicals.qmd
@@ -14,7 +14,7 @@ Neste capítulo, você aprenderá ferramentas para trabalhar com vetores lógico
 Vetores lógicos são a forma mais simples de vetores, pois cada elemento pode ter apenas um dos três possíveis valores: `TRUE`, `FALSE` e `NA`.
 É relativamente raro encontrar vetores lógicos em seus dados brutos, mas você os criará e manipulará no decorrer de quase todas as análises.
 
-Começaremos discutindo a forma mais comum de criar vetores lógicos: com comparações numéricas.
+Começaremos discutindo a forma mais comum de criar vetores lógicos: por meio de comparações numéricas.
 Em seguida, você aprenderá como usar a álgebra booleana para combinar diferentes vetores lógicos, bem como algumas sumarizações úteis.
 Terminaremos com `if_else()` e `case_when()`, duas funções úteis para fazer alterações condicionais alimentadas por vetores lógicos.
 

--- a/logicals.qmd
+++ b/logicals.qmd
@@ -31,7 +31,7 @@ library(tidyverse)
 library (dados)
 ```
 
-No entanto, à medida que começamos a cobrir mais ferramentas, nem sempre haverá um exemplo real perfeito.
+No entanto, à medida que começamos a estudar novas ferramentas, nem sempre haverá um exemplo real perfeito.
 Então, começaremos a criar alguns dados fictícios com `c()`:
 
 ```{r}

--- a/logicals.qmd
+++ b/logicals.qmd
@@ -486,7 +486,7 @@ case_when(
 
 O código é maior, mas também é mais explícito.
 
-Para explicar com `case_when()` funciona, vamos explorar mais alguns casos mais simples.
+Para explicar com `case_when()` funciona, vamos explorar alguns casos mais simples.
 Se nenhum dos casos corresponder, a saída será `NA`:
 
 ```{r}

--- a/logicals.qmd
+++ b/logicals.qmd
@@ -122,7 +122,7 @@ near(x, c(1, 2))
 
 ### Valores faltantes (*missing values*) {#sec-na-comparison}
 
-Os valores faltantes (*missing values) representam o desconhecido, portanto são "contagiosos": quase qualquer operações que envolva um valor desconhecido também será desconhecida:
+Os valores faltantes (*missing values) representam o desconhecido, portanto são "contagiosos": quase qualquer operação que envolva um valor desconhecido também será desconhecida:
 
 ```{r}
 NA > 5

--- a/logicals.qmd
+++ b/logicals.qmd
@@ -487,7 +487,7 @@ case_when(
 O código é maior, mas também é mais explícito.
 
 Para explicar com `case_when()` funciona, vamos explorar mais alguns casos mais simples.
-Se nenhum dos casos correponder, a saída será `NA`:
+Se nenhum dos casos corresponder, a saída será `NA`:
 
 ```{r}
 case_when(

--- a/logicals.qmd
+++ b/logicals.qmd
@@ -570,7 +570,8 @@ Não esperamos que você memorize essas regras, mas elas devem se tornar naturai
 
 3.  Use `ifelse()` para calcular o valor absoluto de um vetor numérico chamado `x`.
 
-4.  Escreva uma declaração `case_when()` que usa as colunas `mes` e `dia` de `voos` para rotular um conjunto de feriados importante dos Estados Unidos (e.g., Dia de Ano Novo, 4 de Julho, Dia de Ação de Graças e Natal).
+4.  Escreva uma declaração `case_when()` que usa as colunas `mes` e `dia` de `voos` para rotular um conjunto de feriados importante dos Estados Unidos (e.g., 7 de Setembro, Tiradentes, Carnaval e Natal[^logicals-5]).
+[^logicals-5]: N.T. - Na versão original em inglês, os feriados são dos Estados Unidos.
     Primeiro crie uma coluna lógica `TRUE` ou `FALSE`, e então uma coluna texto (*character*) que tenha o nome do feriado ou `NA`.
 
 ## Resumo

--- a/logicals.qmd
+++ b/logicals.qmd
@@ -190,7 +190,7 @@ voos |>
 
 Retornaremos a cobrir mais detalhes sobre valores faltantes (*missing values*) no @sec-missing-values.
 
-### Exercócio
+### Exercício
 
 1.  Como `dplyr::near()` funciona? Digite `near` para ver o código fonte. `sqrt(2)^2` é próximo (near) a 2?
 2.  Use `mutate()`, `is.na()` e `count()` juntos para descrever como os valores faltantes (*missing values*) em `horario_saida`, `saida_programada` e `atraso_saida` estão relacionados.

--- a/logicals.qmd
+++ b/logicals.qmd
@@ -321,7 +321,7 @@ voos |>
 ### Exercícios
 
 1.  Encontre todos os voos onde `atraso_chegada` está faltando (*missing*), mas `atraso_saida` não. Encontre todos os voos onde nem `horario_chegada` ou `chegada_prevista` estão faltando, mas `atraso_chegada` está.
-2.  Quantos voos possuem `horiria_saida` faltando? Quais outras variáveis possuem valores faltantes nestes registros? O que podem representar estas linhas?
+2.  Quantos voos possuem `horario_saida` faltando? Quais outras variáveis possuem valores faltantes nestes registros? O que podem representar estas linhas?
 3.  Assumindo que um valor faltante em `horario_saida` implica em um voo cancelado, olhe o número de voos cancelados por dia. Há algum padrão? Há alguma relação entre a proporção de voos cancelados e a média de atraso dos voos não cancelados?
 
 ## Sumarização {#sec-logical-summaries}

--- a/logicals.qmd
+++ b/logicals.qmd
@@ -446,7 +446,7 @@ Por exemplo, isto nos permite criar uma implmentação mínima de `abs()`:
 if_else(x < 0, -x, x)
 ```
 
-Até agora, todos os argumentos usaram os mesmos vetores, mas você pode misturar e combinar isso.
+Até agora, todos os argumentos usaram os mesmos vetores, mas você pode misturar e combinar variáveis.
 Por exemplo, você pode implementar uma versão simples de `coalesce()` desta forma:
 
 ```{r}

--- a/logicals.qmd
+++ b/logicals.qmd
@@ -28,7 +28,7 @@ Também continuaremos a extrair exemplos do conjunto de dados `dados::voos`.
 #| message: false
 
 library(tidyverse)
-library (dados)
+library(dados)
 ```
 
 No entanto, à medida que começamos a estudar novas ferramentas, nem sempre haverá um exemplo real perfeito.
@@ -40,7 +40,7 @@ x * 2
 ```
 
 Isso facilita a explicação de funções individuais, ao custo de dificultar a visualização de como elas podem se aplicar aos seus problemas de dados.
-Apenas lembre-se de que qualquer manipulação que fizermos em um vetor simples (*free-floating*), você poderá fazer em uma variável dentro de *data frame* com `mutate()` e demais funções amigas.
+Apenas lembre-se de que qualquer manipulação que fizermos em um vetor simples, você poderá fazer em uma variável dentro de *data frame* com `mutate()` e demais funções amigas.
 
 ```{r}
 df <- tibble(x)
@@ -51,7 +51,7 @@ df |>
 ## Comparações
 
 Uma forma muito comum de criar um vetor lógico é através de uma comparação numérica usando `<`, `<=`, `>`, `>=`, `!=` e `==`.
-Até agora, criamos principalmente variáveis ​​lógicas transitoriamente dentro de `filter()` --- elas são calculadas, usadas e depois jogadas fora.
+Até agora, criamos principalmente variáveis ​​lógicas temporariamente dentro do `filter()` --- elas são calculadas, usadas e depois jogadas fora.
 Por exemplo, o filtro abaixo encontra todo os voos que sairam durante o dia e chegaram aproximadamente no horário:
 
 ```{r}
@@ -70,7 +70,7 @@ voos |>
   )
 ```
 
-Isto é particularmente útil para lógicas mais complicadas, pois nomeando os passos intermediarios, se torna mais fácil tanto ler o código quanto verificar se cada passo está sendo calculado corretamente.
+Isto é particularmente útil para lógicas mais complicadas, pois nomeando os passos intermediários, se torna mais fácil tanto ler o código quanto verificar se cada passo está sendo calculado corretamente.
 
 Com isto, o filtro inicial é equivalente a:
 
@@ -122,7 +122,7 @@ near(x, c(1, 2))
 
 ### Valores faltantes (*missing values*) {#sec-na-comparison}
 
-Os valores faltantes (*missing values) representam o desconhecido, portanto são "contagiosos": quase qualquer operação que envolva um valor desconhecido também será desconhecida:
+Os valores faltantes (*missing values*) representam o desconhecido, portanto são "contagiosos": quase qualquer operação que envolva um valor desconhecido também será desconhecida:
 
 ```{r}
 NA > 5
@@ -188,16 +188,16 @@ voos |>
   arrange(desc(is.na(horario_saida)), horario_saida)
 ```
 
-Retornaremos a abordar mais detalhes sobre valores faltantes (*missing values*) no @sec-missing-values.
+Voltaremos a abordar mais detalhes sobre valores faltantes (*missing values*) no @sec-missing-values.
 
 ### Exercício
 
 1.  Como `dplyr::near()` funciona? Digite `near` para ver o código fonte. `sqrt(2)^2` é próximo (near) a 2?
 2.  Use `mutate()`, `is.na()` e `count()` juntos para descrever como os valores faltantes (*missing values*) em `horario_saida`, `saida_programada` e `atraso_saida` estão relacionados.
 
-## Algebra booleana
+## Álgebra booleana
 
-Quando você tem múltiplos vetores lógicos, você pode combiná-los usando algebra booleana.
+Quando você tem múltiplos vetores lógicos, você pode combiná-los usando álgebra booleana.
 No R, `&` é "e", `|` é "ou", `!` é "não" e `xor()` é ou exclusivo[^logicals-2].
 Por exemplo, `df |> filter(!is.na(x))` encontra todas as linhas onde `x` está faltando e `df |> filter(x < -10 | x > 0)` encontra todas as linhas onde `x` é menor que -10 ou maior que 0.
 A @fig-bool-ops mostra o conjunto completo de operações booleanas e como elas funcionam.
@@ -229,9 +229,9 @@ Não os use em funções dplyr!
 Eles são chamados de operadores de curto-circuito e retornam sempre apenas um único `TRUE` ou `FALSE`.
 Eles são importantes na programação, não em ciência de dados.
 
-### Valore faltantes (*missing values*) {#sec-na-boolean}
+### Valores faltantes (*missing values*) {#sec-na-boolean}
 
-As regras para valores ausentes na álgebra booleana são um pouco complicadas de explicar porque parecem inconsistentes à primeira vista:
+As regras para valores faltantes na álgebra booleana são um pouco complicadas de explicar porque parecem inconsistentes à primeira vista:
 
 ```{r}
 df <- tibble(x = c(TRUE, FALSE, NA))
@@ -245,12 +245,12 @@ df |>
 
 Para entender o que está acontecendo aqui, pense em `NA | TRUE` (`NA` ou `TRUE`).
 Um valor faltante (*missing value*) em um vetor lógico significa que o valor poderia ser `TRUE` ou `FALSE`.
-`TRUE | TRUE` e `FALSE | TRUE` são ambos `TRUE` pois ao menos um dors termos é `TRUE`.
+`TRUE | TRUE` e `FALSE | TRUE` são ambos `TRUE` pois ao menos um dos termos é `TRUE`.
 `NA | TRUE` também deve ser `TRUE` pois `NA` pode ser `TRUE` ou `FALSE`.
-Ententando, `NA | FALSE` é `NA` pois não sabemos se `NA` é `TRUE` ou `FALSE`.
+Entretanto, `NA | FALSE` é `NA` pois não sabemos se `NA` é `TRUE` ou `FALSE`.
 O mesmo se aplica com `NA & FALSE`.
 
-### Order das operações
+### Ordem das operações
 
 Observe que a ordem das operações não funcionam como em Português.
 Veja o seguinte código que encontra todos os voos que saíram em novembro ou dezembro:
@@ -286,7 +286,7 @@ voos |>
 
 ### `%in%`
 
-Um jeito fácil de evitar o problema de colocar `==`s e `|`s na order correta é usar `%in%`.
+Um jeito fácil de evitar o problema de colocar `==`s e `|`s na ordem correta é usar `%in%`.
 `x %in% y` retorna um vetor lógico de mesmo tamanho que `x` que é `TRUE` sempre que um valor em `x` está em qualquer lugar em `y` .
 
 ```{r}
@@ -336,7 +336,7 @@ Existem dois sumarizadores lógicos: `any()` e `all()`.
 Assim como todas as funções de sumarização, elas retornarão `NA` se houver qualquer valor faltante (*missing value*) presente, e como de costume, você pode não considerá-los usando `na.rm = TRUE`.
 
 Por exemplo, poderíamos usar `all()` e `any()` para descobrir se todos os voos foram atrasados na partida por no máximo uma hora ou se algum voo atrasou na chegada por cinco horas ou mais.
-And using `group_by()` allows us to do that by day:
+E usando `group_by()` podemos fazer isso para cada dia:
 
 ```{r}
 voos |> 
@@ -354,7 +354,7 @@ Isso nos leva aos sumarizadores numéricos.
 ### Sumarizações numéricas de vetores lógicos {#sec-numeric-summaries-of-logicals}
 
 Quando você usa um vetor lógico em um contexto numérico, `TRUE` se torna 1 e `FALSE` se torna 0.
-Isto torna `sum()` e `mean()` muito úteis com vetores lógicos, pois `sum(x)` retorna o número de `TRUE`s e `mean(x)` retorna a proporção de `TRUE`s (pois `mean()` é apenas `sum()` dividido por`length()`).
+Isto torna `sum()` e `mean()` muito úteis com vetores lógicos, pois `sum(x)` retorna o número de `TRUE`s e `mean(x)` retorna a proporção de `TRUE`s (pois `mean()` é `sum()` dividido por `length()`).
 
 Isto, por exemplo, nos permite ver a proporção de voos que tiveram atraso na saída em até uma hora e o número de voos que chegaram atrasados em cinco horas ou mais:
 
@@ -408,7 +408,7 @@ voos |>
 
 Observe também a diferença no tamanho do grupo: no primeiro segmento `n()` tem o número de voos em atraso por dia, no segundo, `n()` retorna o número total de voos.
 
-### Exercises
+### Exercícios
 
 1.  O que `sum(is.na(x))` retorna? E `mean(is.na(x))`?
 2.  O que `prod()` retorna quando aplicada a um vetor lógico? Qual função de sumarização lógica é equivalente? O que `min()` retorna quando aplicada a um vetor lógico? Qual função de sumarização lógica é equivalente? Leia a documentação e efetue alguns experimentos.
@@ -416,15 +416,15 @@ Observe também a diferença no tamanho do grupo: no primeiro segmento `n()` tem
 ## Transformações condicionais
 
 Uma das características mais poderosas de vetores lógico é seu uso em transformações condicionais, i.e. fazer alguma coisa em uma condição x, e alguma outra coisa diferente para a y.
-Existem duas ferramentas importantes para isso: `if_else()` e `case_when()`.
+Existem duas funções importantes para isso: `if_else()` e `case_when()`.
 
 ### `if_else()`
 
 Se você quiser usar um valor para quando a condição é `TRUE` e outro valor para quando a condição é `FALSE`, você pode usar `dplyr::if_else()`[^logicals-4].
-Você sempre usará os primeiros três argumentos de `if_else()`. O primeiro, `condition`, é um vetor lógico, o segundo, `true`, gera uma saída quando a condição é verdadeira (*true*), e o terceiro, `false`, gera uma saída quando a condição é falsa (*false*).
+Você sempre usará os primeiros três argumentos de `if_else()`. O primeiro, `condition`, é um vetor lógico, o segundo, `true`, gera uma saída quando a condição é verdadeira, e o terceiro, `false`, gera uma saída quando a condição é falsa.
 
 [^logicals-4]: A função `if_else()` do dplyr é muito similar a `ifelse()` do R base .
-    Existem duas vantagens principais do `if_else()` sobre `ifelse()`: você pode escolher o que acontece com valor faltantes (*minssing values*) e `if_else()` te retorna erros com mais sentido se sua variável possuir tipos incompatíveis.
+    Existem duas vantagens principais do `if_else()` sobre `ifelse()`: você pode escolher o que acontece com valor faltantes (*missing values*) e `if_else()` te retorna erros com mais sentido se sua variável possuir tipos incompatíveis.
 
 Vamos começar com um simples exemplo rotulando um vetor numérico como "+vo" (positivo) ou "-vo" (negativo):
 
@@ -440,7 +440,7 @@ if_else(x > 0, "+vo", "-vo", "???")
 ```
 
 Você também usar vetores para os argumentos `true` e `false`.
-Por exemplo, isto nos permite criar uma implmentação mínima de `abs()`:
+Por exemplo, isto nos permite criar uma implementação mínima de `abs()`:
 
 ```{r}
 if_else(x < 0, -x, x)
@@ -455,7 +455,7 @@ y1 <- c(3, NA, 4, 6)
 if_else(is.na(x1), y1, x1)
 ```
 
-Você pode notar uma pequena infelicidade em nosso exemplo de rótulo acima: zero não é nem positivo nem negativo.
+Você pode notar uma pequena infelicidade no nosso exemplo de rótulo acima: zero não é nem positivo nem negativo.
 Nós poderíamos resolver isso adicionando um novo `if_else()`:
 
 ```{r}
@@ -467,12 +467,12 @@ Ao invés disso, você deve mudar para o `dplyr::case_when()`.
 
 ### `case_when()`
 
-O `case_when()` do pacote dplyr é inspirado pela declaração `CASE` do SQL e oferece uma forma flexível de efetuar diferentes cálculos para diferentes condições.
+O `case_when()` do pacote dplyr é inspirado na declaração `CASE` do SQL e oferece uma forma flexível de efetuar diferentes cálculos para diferentes condições.
 Infelizmente, ele tem uma sintaxe que não se parece com nada que você usará no pacote tidyverse.
 Ele recebe pares que se parecem com `condição ~ saída`.
 `condição` deve ser um vetor lógico; quando for `TRUE`, `saída` será usada.
 
-Isto significa que poderíamos recriar nos `if_else()` aninhado dest forma:
+Isto significa que poderíamos recriar nos `if_else()` aninhado desta forma:
 
 ```{r}
 x <- c(-3:3, NA)
@@ -496,7 +496,7 @@ case_when(
 )
 ```
 
-Use `.default` se você quiser gerar um "padrão"/pega todos valores:
+Use  o argumento`.default` se você quiser gerar um "padrão"/pegar todos os valores:
 
 ```{r}
 case_when(
@@ -556,7 +556,7 @@ Aqui estão os casos mais importantes que são compatíveis:
 
 -   Vetores numéricos e lógicos são compatíveis, conforme discutimos na @sec-numeric-summaries-of-logicals.
 -   Strings e fatores (@sec-factors) são compatíveis, porque você pode pensar em um fator como uma string com um conjunto restrito de valores.
--   Datas e datas e horas, que discutiremos no @sec-dates-and-times, são compatíveis porque você pode pensar em uma data (*date*) como um caso especial de data_hora (*datetime*).
+-   Data e data-hora, que discutiremos no @sec-dates-and-times, são compatíveis porque você pode pensar em uma data (*date*) como um caso especial de data-hora (*datetime*).
 -   `NA`, que é tecnicamente um vetor lógico, é compatível com tudo porque todo vetor tem alguma forma de representar um valor faltante (*missing value*).
 
 Não esperamos que você memorize essas regras, mas elas devem se tornar naturais com o tempo, porque são aplicadas de forma consistente em todo o tidyverse.
@@ -570,7 +570,7 @@ Não esperamos que você memorize essas regras, mas elas devem se tornar naturai
 
 3.  Use `ifelse()` para calcular o valor absoluto de um vetor numérico chamado `x`.
 
-4.  Escreva uma declaração `case_when()` que usa as colunas `mes` e `dia` de `voos` para rotular um conjunto de feriados importante dos Estados Unidos (e.g., 7 de Setembro, Tiradentes, Carnaval e Natal[^logicals-5]).
+4.  Escreva uma declaração `case_when()` que usa as colunas `mes` e `dia` de `voos` para rotular um conjunto de feriados importante dos Brasil (e.g., 7 de Setembro, Tiradentes, Carnaval e Natal[^logicals-5]).
 [^logicals-5]: N.T. - Na versão original em inglês, os feriados são dos Estados Unidos.
     Primeiro crie uma coluna lógica `TRUE` ou `FALSE`, e então uma coluna texto (*character*) que tenha o nome do feriado ou `NA`.
 

--- a/logicals.qmd
+++ b/logicals.qmd
@@ -188,7 +188,7 @@ voos |>
   arrange(desc(is.na(horario_saida)), horario_saida)
 ```
 
-Retornaremos a cobrir mais detalhes sobre valores faltantes (*missing values*) no @sec-missing-values.
+Retornaremos a abordar mais detalhes sobre valores faltantes (*missing values*) no @sec-missing-values.
 
 ### Exercício
 


### PR DESCRIPTION
Tradução so logicals.qmd
Pontos importante: 

1-) Deixei "base R" como "**R base**". Não tenha certeza se há já outro padrão para o termo (base do R ou algo assim)
2-) datetime, tenho usado "**data_hora**"
3-) Notei que os nomes dos campos em ingles do nycflights13 ("**sched_dep_time**" e "**sched_arr_time**") estão mais "padronizados" que no dados::voos ("**saida_programada**" e "**chegada_prevista**"). O código segue a versão atual, porém se esta for alterada devemos acertar o código deste capítulo.