### PR TITLE
Tradução: joins.qmd

### DIFF
--- a/joins.qmd
+++ b/joins.qmd
@@ -792,7 +792,7 @@ Por exemplo, `join_by(closest(x <= y))` corresponde ao menor `y` que é maior ou
 #|   Uma união deslizante é semelhante a uma união de desigualdade maior ou igual a
 #|   mas corresponde apenas ao primeiro valor.
 #| fig-alt: |
-#|   Uma união dezlizante é um subconjunto de uma união de desigualdade, portanto algumas correspondências são
+#|   Uma união deslizante é um subconjunto de uma união de desigualdade, portanto algumas correspondências são
 #|   acinzentadas indicando que eles não são usados ​​porque não são os 
 #|   valores "mais próximos".
 knitr::include_graphics("diagrams/join/closest.png", dpi = 270)

--- a/joins.qmd
+++ b/joins.qmd
@@ -24,7 +24,9 @@ Terminaremos com uma discussão sobre uniões não-equivalentes (*non-equi joins
 
 ### Pré-requisitos
 
-Neste capítulo, exploraremos os cinco conjuntos de dados relacionados do pacote dados usando as funções de união do pacote dplyr.
+Neste capítulo, exploraremos os cinco conjuntos de dados relacionados do pacote nycflights13[^nt-joins-1] usando as funções de união do pacote dplyr.
+
+[^nt-joins-1]: **Nota de tradução**: Disponíveis em português no pacotes [dados](https://cienciadedatos.github.io/dados/).
 
 ```{r}
 #| label: setup
@@ -34,20 +36,20 @@ library(tidyverse)
 library(dados)
 ```
 
-## Chaves
+## Chaves (*keys*)
 
 Para entender as uniões (*joins*), primeiro você precisa entender como duas tabelas podem ser conectadas por meio de um par de chaves (*keys*), dentro de cada tabela.
-Nesta seção, você aprenderá sobre os dois tipos de chave e verá exemplos de ambos nos conjuntos de dados do pacote dados.
+Nesta seção, você aprenderá sobre os dois tipos de chave e verá exemplos de ambos nos conjuntos de dados do pacote nycflights13.
 Você também aprenderá como verificar se suas chaves são válidas e o que fazer se sua tabela não tiver uma chave.
 
 ### Chaves primárias e chaves estrangeiras
 
-Cada união envolve um par de chaves: uma chave primária (*primary key*) e uma chave estrangeira (*foreign key*).
+Cada união (*join*) envolve um par de chaves (*key*): uma chave primária (*primary key*) e uma chave estrangeira (*foreign key*).
 Uma **chave primária** é uma variável ou conjunto de variáveis ​​que identifica exclusivamente cada observação.
-Quando mais de uma variável é necessária, a chave é chamada de **chave primária composta.** (*compound primary key*). Por exemplo, no pacote dados:
+Quando são necessárias mais de uma variável, a chave é denominada de chave primária composta (*compound primary key*). Por exemplo, no pacote dados:
 
 -   `companhias_aereas` registra dois dados sobre cada companhia aérea: seu código e seu nome completo.
-    Você pode identificar uma companhia aérea com seu código de operadora de duas letras, tornando `companhia_aerea` a chave primária (*primary key*).
+    Você pode identificar uma companhia aérea com seu código de transportadora de duas letras, tornando `companhia_aerea` a chave primária (*primary key*).
 
     ```{r}
     companhias_aereas
@@ -71,8 +73,8 @@ Quando mais de uma variável é necessária, a chave é chamada de **chave prim�
     avioes
     ```
 
--   `clima` registra dados sobre cada os aeroportos de orgigem.
-    Você pode identificar cada observação pela combinação de origem e horário, tornando `origem` e `data_hora` a chave primária composta (*compound primary key*).
+-   `clima` registra dados sobre o clima nos aeroportos de origem.
+    Você pode identificar cada observação pela combinação de localização (origem do aeroporto) e horário, tornando `origem`e `data_hora` a chave primária composta (*compound primary key*).
 
     ```{r}
     #| R.options:
@@ -111,9 +113,9 @@ Estes relacionamentos estão resumidos visualmente na @fig-flights-relationships
 knitr::include_graphics("diagrams/relational.png", dpi = 270)
 ```
 
-Você notará um recurso interessante no design dessas chaves: as chaves primária e estrangeira quase sempre têm os mesmos nomes, o que, como você verá em breve, tornará sua vida para as uniões (*joins*) muito mais fácil.
+Você notará um recurso interessante no design dessas chaves: as chaves primária (*primary key*) e estrangeira (*foreign key*) quase sempre têm os mesmos nomes, o que, como você verá em breve, tornará sua vida para as uniões (*joins*) muito mais fácil.
 Também vale a pena notar a relação oposta: quase todos os nomes de variáveis ​​usados ​​em múltiplas tabelas têm o mesmo significado em cada lugar.
-Há apenas uma exceção: `ano` significa ano de saída em `voos` e ano de fabricação em `aviões`.
+Há apenas uma exceção: `ano` significa ano de partida em `voos` e ano de fabricação em `avioes`.
 Isso se tornará importante quando começarmos a unir as tabelas.
 
 ### Verificando chaves primárias
@@ -142,7 +144,7 @@ clima |>
   filter(is.na(data_hora) | is.na(origem))
 ```
 
-### Chaves substitutas
+### Chaves substitutas (*Surrogate keys*)
 
 Até agora não falamos sobre a chave primária para `voos`..
 Não é muito importante aqui, porque não existem quadros de dados que o utilizem como chave estrangeira, mas ainda é útil considerar porque é mais fácil trabalhar com observações se tivermos alguma maneira de descrevê-las para outras pessoas.

--- a/joins.qmd
+++ b/joins.qmd
@@ -707,7 +707,7 @@ As funções de união do pacote dplyr entendem essa distinção entre uniões e
 #|   chave em `y`. Muitas linhas geram múltiplas correspondências.
 #| fig-alt: |
 #|   Um diagrama de união ilustrando join_by(chave >= chave). A primeira linha
-#|   de x corresponde a uma linha de y e a segunda e terceira linhas correspondem
+#|   de x corresponde a uma linha de y e a segunda e terceira linhas correspondem a
 #|   duas linhas. Isso significa que a saída tem cinco linhas contendo cada um dos 
 #|   seguintes pares (chave.x, chave.y): (1, 1), (2, 1), (2, 2), (3, 1),
 #|   (3, 2).
@@ -721,9 +721,9 @@ União não-equivalente (*non-equi join*) não é um termo particularmente útil
 -   **Uniões deslizantes** (*rolling joins*) são semelhantes às uniões de desigualdade, mas apenas encontram a correspondência mais próxima.
 -   **Uniões de sobreposições** (*overlap joins*) são um tipo especial de união de desigualdade projetada para trabalhar com intervalos.
 
-Each of these is described in more detail in the following sections.
+Cada um deles é descrito em maiores detalhes nas seções a seguir.
 
-### Uniões cruzadas
+### Uniões cruzadas (*Cross joins*)
 
 Uma união cruzada (*cross join*) corresponde a tudo, como na @fig-join-cross, gerando o produto cartesiano de linhas.
 Isso significa que a saída terá linhas `nrow(x) * nrow(y)`.
@@ -739,19 +739,19 @@ Isso significa que a saída terá linhas `nrow(x) * nrow(y)`.
 knitr::include_graphics("diagrams/join/cross.png", dpi = 270)
 ```
 
-As uniõescruzadas são úteis ao gerar permutações.
+As uniões cruzadas são úteis ao gerar permutações.
 Por exemplo, o código abaixo gera todos os pares possíveis de nomes.
 Como estamos unindo `df` a ele mesmo, isso às vezes é chamado de **auto-união** (*self-join*).
-As uniões cruzadas usam uma função de união diferente porque não há distinção entre interno/esquerdo/direito/completo quando você corresponde a cada linha
+As uniões cruzadas usam uma função de união diferente porque não há distinção entre interno/esquerdo/direito/completo quando você corresponde todas as linhas.
 
 ```{r}
 df <- tibble(name = c("John", "Simon", "Tracy", "Max"))
 df |> cross_join(df)
 ```
 
-### Uniões de desigualdades
+### Uniões de desigualdades (*Inequality joins*)
 
-Uniões de desigualdade (*inequality joins*) usam `<`, `<=`, `>=` ou `>` para restringir o conjunto de correspondências possíveis, como na @fig-join-gte e na @fig-join-lt.
+Uniões de desigualdade (*inequality joins*) usam `<`, `<=`, `>=` ou `>` para restringir o conjunto de correspondências possíveis, como em @fig-join-gte e @fig-join-lt.
 
 ```{r}
 #| label: fig-join-lt
@@ -759,17 +759,17 @@ Uniões de desigualdade (*inequality joins*) usam `<`, `<=`, `>=` ou `>` para re
 #| out-width: ~
 #| fig-cap: |
 #|  Uma união de desigualdade onde `x` é unido a `y` nas linhas onde a chave 
-#|   de `x` é menor que a chave de `y`. Isso forma um triângulo
+#|   de `x` é menor que a chave de `y`. Isso retorna uma forma triangular
 #|   no canto superior esquerdo.
 #| fig-alt: |
 #|   Um diagrama que descreve uma união de desigualdade onde um quadro de dados x é unido por 
 #|   um data frame y onde a chave de x é menor que a chave de y, resultando 
-#|   em um triangulo no canto superior esquerdo.
+#|   em uma forma triangular no canto superior esquerdo.
 
 knitr::include_graphics("diagrams/join/lt.png", dpi = 270)
 ```
 
-As uniões de desigualdade são extremamente gerais, tão gerais que é difícil encontrar casos de uso específicos significativos.
+As uniões de desigualdade são extremamente gerais, tão gerais que é difícil encontrar casos relevantes de uso específico.
 Uma pequena técnica útil é usá-los para restringir a união cruzada de modo que, em vez de gerar todas as permutações, geremos todas as combinações:
 
 ```{r}
@@ -778,9 +778,9 @@ df <- tibble(id = 1:4, name = c("John", "Simon", "Tracy", "Max"))
 df |> inner_join(df, join_by(id < id))
 ```
 
-### Uniões deslizantes
+### Uniões deslizantes (*Rolling joins*)
 
-Uniões deslizantes (*rolling joins*) são um tipo especial de uniã0 de desigualdade onde, em vez de obter *todas* as linhas que satisfaçam a desigualdade, você obtém apenas a linha mais próxima, como na @ fig-join-closest.
+Uniões deslizantes (*rolling joins*) são um tipo especial de união de desigualdade em que ao invés de obter *todas* as linhas que satisfaçam a desigualdade, você obtém apenas a linha mais próxima, como na @ fig-join-closest.
 Você pode transformar qualquer união de desigualdade em uma união deslizante adicionando a função `closest()`.
 Por exemplo, `join_by(closest(x <= y))` corresponde ao menor `y` que é maior ou igual a x, e `join_by(closest(x > y))` corresponde ao maior `y` que é menor que ` x`
 
@@ -789,10 +789,10 @@ Por exemplo, `join_by(closest(x <= y))` corresponde ao menor `y` que é maior ou
 #| echo: false
 #| out-width: ~
 #| fig-cap: |
-#|   Uma união deslizante é semelhante a uma união de desigualdade maior ou igual
+#|   Uma união deslizante é semelhante a uma união de desigualdade maior ou igual a
 #|   mas corresponde apenas ao primeiro valor.
 #| fig-alt: |
-#|   Uma união dezlizante é um subconjunto de uma uniçao de desigualdade, portanto algumas correspondências são
+#|   Uma união dezlizante é um subconjunto de uma união de desigualdade, portanto algumas correspondências são
 #|   acinzentadas indicando que eles não são usados ​​porque não são os 
 #|   valores "mais próximos".
 knitr::include_graphics("diagrams/join/closest.png", dpi = 270)
@@ -838,7 +838,7 @@ funcionarios |>
   anti_join(festas, join_by(closest(aniversario >= festa)))
 ```
 
-Para resolver esse problema, precisaremos abordar o problema de uma maneira diferente, com uniões de sobreposições (*overlap joins*).
+Para resolver este problema, precisaremos abordar o problema de uma maneira diferente, com uniões de sobreposições (*overlap joins*).
 
 ### Uniões de sobreposições
 
@@ -871,7 +871,7 @@ festas |>
   select(inicio.x, fim.x, inicio.y, fim.y)
 ```
 
-Ops, há uma sobreposição, então vamos corrigir esse problema e continuar:
+Ops, há uma sobreposição, então vamos corrigir este problema e continuar:
 
 ```{r}
 festas <- tibble(
@@ -910,7 +910,7 @@ funcionarios |>
 Neste capítulo, você aprendeu como usar uniões de mutações (*mutating joins*) e filtragem (*filtering joins*) para combinar dados de dois *data frames*.
 Ao longo do caminho você aprendeu como identificar chaves (*keys*) e a diferença entre chaves primárias (*primary keys*) e estrangeiras (*foreign keys*).
 Você também entende como funcionam as uniões e como descobrir quantas linhas a saída terá.
-Finalmente, você teve uma ideia do poder das uniões não-equivalentes (*non-equi joins*) e viu alguns casos de uso interessantes.
+Finalmente, você teve uma ideia do poder das uniões não-equivalentes (*non-equi joins*) e viu alguns casos interessantes de seu uso.
 
 Este capítulo conclui a parte "Transformar" do livro, onde o foco estava nas ferramentas que você poderia usar com colunas e tabelas individuais.
 Você aprendeu sobre o pacote dyplr e suas funções base para trabalhar com vetores lógicos, números e tabelas completas, funções do pacote stringr para trabalhar com strings, funções do pacote lubridate para trabalhar com datas e horários e funções do pacote forcats para trabalhar com fatores.

--- a/joins.qmd
+++ b/joins.qmd
@@ -146,7 +146,7 @@ clima |>
 
 ### Chaves substitutas (*Surrogate keys*)
 
-Até agora não falamos sobre a chave primária para `voos`..
+Até agora não falamos sobre a chave primária para `voos`.
 Não é muito importante aqui, porque não existem quadros de dados que o utilizem como chave estrangeira, mas ainda é útil considerar porque é mais fácil trabalhar com observações se tivermos alguma maneira de descrevê-las para outras pessoas.
 
 Após um pouco de reflexão e experimentação, determinamos que existem três variáveis ​​que juntas identificam cada voo de forma única:

--- a/joins.qmd
+++ b/joins.qmd
@@ -147,7 +147,7 @@ clima |>
 ### Chaves substitutas (*Surrogate keys*)
 
 Até agora não falamos sobre a chave primária para `voos`.
-Não é muito importante aqui, porque não existem quadros de dados que o utilizem como chave estrangeira, mas ainda é útil considerar porque é mais fácil trabalhar com observações se tivermos alguma maneira de descrevê-las para outras pessoas.
+Não é muito importante aqui, porque não existem *data frames* que o utilizem como chave estrangeira, mas ainda é útil considerar porque é mais fácil trabalhar com observações se tivermos alguma maneira de descrevê-las para outras pessoas.
 
 Após um pouco de reflexão e experimentação, determinamos que existem três variáveis ​​que juntas identificam cada voo de forma única:
 
@@ -167,10 +167,10 @@ aeroportos |>
   filter(n > 1)
 ```
 
-Identificar um aeroporto pela sua latitude e longitude é claramente uma má ideia e, em geral, não é possível saber apenas a partir dos dados se uma combinação de variáveis ​​constitui ou não uma boa chave primária..
+Identificar um aeroporto pela sua latitude e longitude é claramente uma má ideia e, em geral, não é possível saber apenas a partir dos dados se uma combinação de variáveis ​​constitui ou não uma boa chave primária.
 Mas para voos, a combinação de `data_hora`,`companhia_aerea` e `voo` parece razoável porque seria muito confuso para uma companhia aérea e seus clientes se houvesse vários voos com o mesmo número de voo no ar ao mesmo tempo.
 
-Dito isto, seria melhor introduzir uma chave substituta numérica simples usando o número da linha:
+Dito isto, seria melhor introduzir uma chave substituta (*surrogate key*) numérica simples usando o número da linha:
 
 ```{r}
 voos2 <- voos |> 
@@ -209,7 +209,7 @@ A ordem das linhas e colunas na saída é determinada principalmente por `x`.
 Nesta seção, você aprenderá como usar uma união mutante (*mutating join*), `left_join()`, e duas uniões de filtragem (*filtering join*), `semi_join()` e `anti_join()`.
 Na próxima seção, você aprenderá exatamente como essas funções funcionam e também sobre as outras funções `inner_join()`, `right_join()` e `full_join()`
 
-### Uniões de mutação
+### Uniões de mutação (*Mutating joins*)
 
 Uma **união de mutação** (*mutating join*), permite combinar variáveis ​​de dois *data frames*: primeiro ela combina as observações por suas chaves e depois copia as variáveis ​​de um *data frame* para outro.
 Assim como `mutate()`, as funções de união (*joins*) adicionam variáveis ​​à direita, portanto, se o seu conjunto de dados tiver muitas variáveis, você não verá as novas.
@@ -260,9 +260,9 @@ voos2 |>
 
 Voltaremos a esse problema algumas vezes no restante do capítulo.
 
-### Especificando chaves das uniões
+### Especificando chaves das uniões (*join keys*)
 
-Por padrão, `left_join()` usará todas as variáveis ​​que aparecem em ambos os *data frames* como a chave de união, a chamada união **natural** (*natural join*).
+Por padrão, `left_join()` usará todas as variáveis ​​que aparecem em ambos os *data frames* como a chave de união (*join key*), a chamada união **natural** (*natural join*).
 Esta é uma heurística útil, mas nem sempre funciona.
 Por exemplo, o que acontece se tentarmos unir `voos2` com o conjunto de dados completo `avioes`
 
@@ -280,7 +280,7 @@ voos2 |>
   left_join(avioes, join_by(codigo_cauda))
 ```
 
-Observe que as variáveis ​​`ano` são desambiguadas na saída com um sufixo (`ano.x` e `ano.y`), que informa se a variável veio do argumento `x` ou `y`.
+Observe que as variáveis ​​`ano` são diferenciadas na saída com um sufixo (`ano.x` e `ano.y`), que informa se a variável veio do argumento `x` ou `y`.
 Você pode substituir os sufixos padrão pelo argumento `suffix`.
 
 `join_by(codigo_cauda)` é a abreviação de `join_by(codigo_cauda == codigo_cauda)`.
@@ -289,7 +289,7 @@ Em primeiro lugar, descreve a relação entre as duas tabelas: as chaves devem s
 É por isso que esse tipo de junção costuma ser chamado de **união equivalente** (*equi join*).
 Você aprenderá sobre uniões não equivalentes (*non-equi join*) na @sec-non-equi-joins.
 
-Em segundo lugar, é como você especifica diferentes chaves de união em cada tabela.
+Em segundo lugar, é como você especifica diferentes chaves de união (*join keys*) em cada tabela.
 Por exemplo, existem duas maneiras de unir as tabelas `voos2` e `aeroportos`: por `destino` ou `origem`:
 
 ```{r}
@@ -305,7 +305,7 @@ Em códigos mais antigos, você pode ver uma maneira diferente de especificar as
 -   `by = "x"` corresponde a `join_by(x)`.
 -   `by = c("a" = "x")` corresponde a `join_by(a == x)`.
 
-Agora que existe, preferimos `join_by()` pois fornece uma especificação mais clara e flexível.
+Agora que isto existe, preferimos `join_by()` pois fornece uma especificação mais clara e flexível.
 
 `inner_join()`, `right_join()`, `full_join()` têm a mesma interface que `left_join()`.
 A diferença é quais linhas elas mantêm: a *left join* mantém todas as linhas em `x`, a *right join* mantém todas as linhas em `y`, a *full join* mantém todas as linhas em `x` ou `y`, e a *inner join* mantém apenas as linhas que ocorrem em `x` e `y`.

--- a/joins.qmd
+++ b/joins.qmd
@@ -1,337 +1,337 @@
-# Joins {#sec-joins}
+# Uniões {#sec-joins}
 
 ```{r}
 #| echo: false
 #| results: asis
 
 source("_common.R")
-mensagem_capitulo_sem_traducao()
+
 ```
 
-## Introduction
+## Introdução
 
-It's rare that a data analysis involves only a single data frame.
-Typically you have many data frames, and you must **join** them together to answer the questions that you're interested in.
-This chapter will introduce you to two important types of joins:
+É raro que uma análise de dados envolva apenas um único *data frame*.
+Normalmente você tem muitos quadros de dados e deve **uní-los** (*joins*) para responder às perguntas de seu interesse.
+Este capítulo apresentará dois tipos importantes de uniões (*joins*):
 
--   Mutating joins, which add new variables to one data frame from matching observations in another.
--   Filtering joins, which filter observations from one data frame based on whether or not they match an observation in another.
+-   Uniões de mutação (*mutating joins*), que adicionam novas variáveis ​​a um *data frame* a partir de observações correspondentes em outro.
+-   Uniões de filtragem (*filtering joins*), que filtram observações de um *data frame* com base na correspondência ou não com uma observação em outro.
 
-We'll begin by discussing keys, the variables used to connect a pair of data frames in a join.
-We cement the theory with an examination of the keys in the datasets from the nycflights13 package, then use that knowledge to start joining data frames together.
-Next we'll discuss how joins work, focusing on their action on the rows.
-We'll finish up with a discussion of non-equi joins, a family of joins that provide a more flexible way of matching keys than the default equality relationship.
+Começaremos discutindo as chaves (*keys*), as variáveis ​​usadas para conectar um par de *data frames* através de uma união.
+Consolidamos a teoria com examinando as chaves (*keys*) no conjuntos de dados do pacote dados e, em seguida, usamos esse conhecimento para começar a unir os *data frames*.
+A seguir discutiremos como funcionam as uniões (*joins*), focando em sua ação nas linhas.
+Terminaremos com uma discussão sobre uniões não-equivalentes (*non-equi joins*), uma família de uniões que fornece uma maneira mais flexível de combinar chaves (*keys*) do que o relacionamento de igualdade padrão.
 
-### Prerequisites
+### Pré-requisitos
 
-In this chapter, we'll explore the five related datasets from nycflights13 using the join functions from dplyr.
+Neste capítulo, exploraremos os cinco conjuntos de dados relacionados do pacote dados usando as funções de união do pacote dplyr.
 
 ```{r}
 #| label: setup
 #| message: false
 
 library(tidyverse)
-library(nycflights13)
+library(dados)
 ```
 
-## Keys
+## Chaves
 
-To understand joins, you need to first understand how two tables can be connected through a pair of keys, within each table.
-In this section, you'll learn about the two types of key and see examples of both in the datasets of the nycflights13 package.
-You'll also learn how to check that your keys are valid, and what to do if your table lacks a key.
+Para entender as uniões (*joins*), primeiro você precisa entender como duas tabelas podem ser conectadas por meio de um par de chaves (*keys*), dentro de cada tabela.
+Nesta seção, você aprenderá sobre os dois tipos de chave e verá exemplos de ambos nos conjuntos de dados do pacote dados.
+Você também aprenderá como verificar se suas chaves são válidas e o que fazer se sua tabela não tiver uma chave.
 
-### Primary and foreign keys
+### Chaves primárias e chaves estrangeiras
 
-Every join involves a pair of keys: a primary key and a foreign key.
-A **primary key** is a variable or set of variables that uniquely identifies each observation.
-When more than one variable is needed, the key is called a **compound key.** For example, in nycflights13:
+Cada união envolve um par de chaves: uma chave primária (*primary key*) e uma chave estrangeira (*foreign key*).
+Uma **chave primária** é uma variável ou conjunto de variáveis ​​que identifica exclusivamente cada observação.
+Quando mais de uma variável é necessária, a chave é chamada de **chave primária composta.** (*compound primary key*). Por exemplo, no pacote dados:
 
--   `airlines` records two pieces of data about each airline: its carrier code and its full name.
-    You can identify an airline with its two letter carrier code, making `carrier` the primary key.
-
-    ```{r}
-    airlines
-    ```
-
--   `airports` records data about each airport.
-    You can identify each airport by its three letter airport code, making `faa` the primary key.
+-   `companhias_aereas` registra dois dados sobre cada companhia aérea: seu código e seu nome completo.
+    Você pode identificar uma companhia aérea com seu código de operadora de duas letras, tornando `companhia_aerea` a chave primária (*primary key*).
 
     ```{r}
-    #| R.options:
-    #|   width: 67
-    airports
+    companhias_aereas
     ```
 
--   `planes` records data about each plane.
-    You can identify a plane by its tail number, making `tailnum` the primary key.
+-   `aeroportos` registra dados sobre cada aeroporto.
+    Você pode identificar cada aeroporto pelo seu código de aeroporto de três letras, tornando `codigo_aeroporto` a chave primária.
 
     ```{r}
     #| R.options:
     #|   width: 67
-    planes
+    aeroportos
     ```
 
--   `weather` records data about the weather at the origin airports.
-    You can identify each observation by the combination of location and time, making `origin` and `time_hour` the compound primary key.
+-   `avioes` registra dados sobre cada aeronave.
+    Você pode identificar um avião pelo seu número de cauda, ​​tornando `codigo_cauda` a chave primária.
 
     ```{r}
     #| R.options:
     #|   width: 67
-    weather
+    avioes
     ```
 
-A **foreign key** is a variable (or set of variables) that corresponds to a primary key in another table.
-For example:
+-   `clima` registra dados sobre cada os aeroportos de orgigem.
+    Você pode identificar cada observação pela combinação de origem e horário, tornando `origem` e `data_hora` a chave primária composta (*compound primary key*).
 
--   `flights$tailnum` is a foreign key that corresponds to the primary key `planes$tailnum`.
--   `flights$carrier` is a foreign key that corresponds to the primary key `airlines$carrier`.
--   `flights$origin` is a foreign key that corresponds to the primary key `airports$faa`.
--   `flights$dest` is a foreign key that corresponds to the primary key `airports$faa`.
--   `flights$origin`-`flights$time_hour` is a compound foreign key that corresponds to the compound primary key `weather$origin`-`weather$time_hour`.
+    ```{r}
+    #| R.options:
+    #|   width: 67
+    clima
+    ```
 
-These relationships are summarized visually in @fig-flights-relationships.
+Uma **chave estrangeira** (*foreign key*) é uma variável (ou conjunto de variáveis) que corresponde a uma chave primária em outra tabela.
+Por exemplo:
+
+-   `voos$codigo_cauda` é uma chave estrangeira que corresponde à chave primária `avioes$codigo_cauda`.
+-   `voos$companhia_aerea` é uma chave estrangeira que corresponde à chave primária `companhias_aereas$companhia_aerea`.
+-   `voos$origem` é uma chave estrangeira que corresponde à chave primária `aeroportos$codigo_aeroporto`.
+-   `voos$destino` é uma chave estrangeira que corresponde à chave primária `aeroportos$codigo_aeroporto`.
+-   `voos$origem`-`voos$data_hora` é uma chave estrangeira composta que corresponde à chave primária composta  `clima$origem`-`clima$data_hora`.
+
+Estes relacionamentos estão resumidos visualmente na @fig-flights-relationships.
 
 ```{r}
 #| label: fig-flights-relationships
 #| echo: false
 #| out-width: ~
 #| fig-cap: |
-#|   Connections between all five data frames in the nycflights13 package.
-#|   Variables making up a primary key are colored grey, and are connected
-#|   to their corresponding foreign keys with arrows.
+#|   Conexões entre cinco data frames no pacote dados.
+#|   As variáveis ​​que compõem uma chave primária são coloridas em cinza e estão conectadas
+#|   às suas chaves estrangeiras correspondentes com setas.
 #| fig-alt: |
-#|   The relationships between airports, planes, flights, weather, and
-#|   airlines datasets from the nycflights13 package. airports$faa
-#|   connected to the flights$origin and flights$dest. planes$tailnum
-#|   is connected to the flights$tailnum. weather$time_hour and
-#|   weather$origin are jointly connected to flights$time_hour and 
-#|   flights$origin. airlines$carrier is connected to flights$carrier.
-#|   There are no direct connections between airports, planes, airlines, 
-#|   and weather data frames.
+#|   As relações entre os data frames aeroportos, aviões, voos, clima e
+#|   companhias aéreas do pacote dados. aeroportos$codigo_aeroporto
+#|   está conectado aos voos$origem e voos$destino. aviões$codgio_cauda
+#|   está conectado aos voos$codigo_cauda. clima$data_hora e
+#|   clima$origem estão conectados conjuntamente aos voos$data_hora e 
+#|   voos$origem. companhias_aereas$companhia_aerea está conectado a voos$companhi_aerea.
+#|   Não existem ligações directas os data frames aeroportos, aviões, companhias aéreas, 
+#|   e clima.
 knitr::include_graphics("diagrams/relational.png", dpi = 270)
 ```
 
-You'll notice a nice feature in the design of these keys: the primary and foreign keys almost always have the same names, which, as you'll see shortly, will make your joining life much easier.
-It's also worth noting the opposite relationship: almost every variable name used in multiple tables has the same meaning in each place.
-There's only one exception: `year` means year of departure in `flights` and year of manufacturer in `planes`.
-This will become important when we start actually joining tables together.
+Você notará um recurso interessante no design dessas chaves: as chaves primária e estrangeira quase sempre têm os mesmos nomes, o que, como você verá em breve, tornará sua vida para as uniões (*joins*) muito mais fácil.
+Também vale a pena notar a relação oposta: quase todos os nomes de variáveis ​​usados ​​em múltiplas tabelas têm o mesmo significado em cada lugar.
+Há apenas uma exceção: `ano` significa ano de saída em `voos` e ano de fabricação em `aviões`.
+Isso se tornará importante quando começarmos a unir as tabelas.
 
-### Checking primary keys
+### Verificando chaves primárias
 
-Now that that we've identified the primary keys in each table, it's good practice to verify that they do indeed uniquely identify each observation.
-One way to do that is to `count()` the primary keys and look for entries where `n` is greater than one.
-This reveals that `planes` and `weather` both look good:
+Agora que identificamos as chaves primárias em cada tabela, é uma boa prática verificar se elas realmente identificam cada observação de forma única.
+Uma maneira de fazer isso é contar com a função `count()` as chaves primárias e procurar entradas onde `n` é maior que um.
+Isso revela que `aviões` e `clima` parecem bons:
 
 ```{r}
-planes |> 
-  count(tailnum) |> 
+avioes |> 
+  count(codigo_cauda) |> 
   filter(n > 1)
 
-weather |> 
-  count(time_hour, origin) |> 
-  filter(n > 1)
-```
-
-You should also check for missing values in your primary keys --- if a value is missing then it can't identify an observation!
-
-```{r}
-planes |> 
-  filter(is.na(tailnum))
-
-weather |> 
-  filter(is.na(time_hour) | is.na(origin))
-```
-
-### Surrogate keys
-
-So far we haven't talked about the primary key for `flights`.
-It's not super important here, because there are no data frames that use it as a foreign key, but it's still useful to consider because it's easier to work with observations if we have some way to describe them to others.
-
-After a little thinking and experimentation, we determined that there are three variables that together uniquely identify each flight:
-
-```{r}
-flights |> 
-  count(time_hour, carrier, flight) |> 
+clima |> 
+  count(data_hora, origem) |> 
   filter(n > 1)
 ```
 
-Does the absence of duplicates automatically make `time_hour`-`carrier`-`flight` a primary key?
-It's certainly a good start, but it doesn't guarantee it.
-For example, are altitude and latitude a good primary key for `airports`?
+Você também deve verificar se há valores ausentes (*missing values*) em suas chaves primárias – se um valor estiver faltando, ele não poderá identificar uma observação!
 
 ```{r}
-airports |>
-  count(alt, lat) |> 
+avioes |> 
+  filter(is.na(codigo_cauda))
+
+clima |> 
+  filter(is.na(data_hora) | is.na(origem))
+```
+
+### Chaves substitutas
+
+Até agora não falamos sobre a chave primária para `voos`..
+Não é muito importante aqui, porque não existem quadros de dados que o utilizem como chave estrangeira, mas ainda é útil considerar porque é mais fácil trabalhar com observações se tivermos alguma maneira de descrevê-las para outras pessoas.
+
+Após um pouco de reflexão e experimentação, determinamos que existem três variáveis ​​que juntas identificam cada voo de forma única:
+
+```{r}
+voos |> 
+  count(data_hora, companhia_aerea, voo) |> 
   filter(n > 1)
 ```
 
-Identifying an airport by its altitude and latitude is clearly a bad idea, and in general it's not possible to know from the data alone whether or not a combination of variables makes a good a primary key.
-But for flights, the combination of `time_hour`, `carrier`, and `flight` seems reasonable because it would be really confusing for an airline and its customers if there were multiple flights with the same flight number in the air at the same time.
-
-That said, we might be better off introducing a simple numeric surrogate key using the row number:
+A ausência de linhas duplicadas torna automaticamente `data_hora`-`companhia_aerea`-`voo` uma chave primária?
+Certamente é um bom começo, mas não garante isso.
+Por exemplo, latitude e longitude são boas chaves primárias para `aeroportos`?
 
 ```{r}
-flights2 <- flights |> 
+aeroportos |>
+  count(latitude, longitude) |> 
+  filter(n > 1)
+```
+
+Identificar um aeroporto pela sua latitude e longitude é claramente uma má ideia e, em geral, não é possível saber apenas a partir dos dados se uma combinação de variáveis ​​constitui ou não uma boa chave primária..
+Mas para voos, a combinação de `data_hora`,`companhia_aerea` e `voo` parece razoável porque seria muito confuso para uma companhia aérea e seus clientes se houvesse vários voos com o mesmo número de voo no ar ao mesmo tempo.
+
+Dito isto, seria melhor introduzir uma chave substituta numérica simples usando o número da linha:
+
+```{r}
+voos2 <- voos |> 
   mutate(id = row_number(), .before = 1)
-flights2
+voos2
 ```
 
-Surrogate keys can be particularly useful when communicating to other humans: it's much easier to tell someone to take a look at flight 2001 than to say look at UA430 which departed 9am 2013-01-03.
+Chaves substitutas podem ser particularmente úteis na comunicação com outras pessoas: é muito mais fácil dizer a alguém para dar uma olhada no voo 2001 do que dizer para olhar o UA430, que partiu às 9h.
 
-### Exercises
+### Exercícios
 
-1.  We forgot to draw the relationship between `weather` and `airports` in @fig-flights-relationships.
-    What is the relationship and how should it appear in the diagram?
+1.  Esquecemos de desenhar a relação entre `clima` e `aeroportos` na @fig-flights-relationships.
+    Qual é a relação e como ela deveria aparecer no diagrama?
 
-2.  `weather` only contains information for the three origin airports in NYC.
-    If it contained weather records for all airports in the USA, what additional connection would it make to `flights`?
+2.  `clima` contém apenas informações para os três aeroportos de origem em Nova York (NYC).
+    Se contivesse registros meteorológicos para todos os aeroportos dos EUA, que conexão adicional faria com `voos`?
 
-3.  The `year`, `month`, `day`, `hour`, and `origin` variables almost form a compound key for `weather`, but there's one hour that has duplicate observations.
-    Can you figure out what's special about that hour?
+3.  As variáveis ​​`ano`, `mês`, `dia`, `hora` e `origem` quase formam uma chave composta para `clima`, mas há uma hora que tem observações duplicadas.
+    Você consegue descobrir o que há de especial naquela hora?
 
-4.  We know that some days of the year are special and fewer people than usual fly on them (e.g., Christmas eve and Christmas day).
-    How might you represent that data as a data frame?
-    What would be the primary key?
-    How would it connect to the existing data frames?
+4.  Sabemos que alguns dias do ano são especiais e menos pessoas do que o normal voam neles (por exemplo, véspera de Natal e dia de Natal).
+    Como você poderia representar esses dados como um *data frame*?
+    Qual seria a chave primária?
+    Como ele se conectaria aos *data frames* existentes?
 
-5.  Draw a diagram illustrating the connections between the `Batting`, `People`, and `Salaries` data frames in the Lahman package.
-    Draw another diagram that shows the relationship between `People`, `Managers`, `AwardsManagers`.
-    How would you characterize the relationship between the `Batting`, `Pitching`, and `Fielding` data frames?
+5.  Desenhe um diagrama ilustrando as conexões entre os *data frames* `rebatedores`, `pessoas` e `salarios` do pacote dados.
+    Desenhe outro diagrama que mostre o relacionamento entre `pessoas`, `gerentes`, `premios_gerentes`.
+    Como você caracterizaria a relação entre os *data frames* `rebatedores`, `arremessadores` e `jardineiros`?
 
-## Basic joins {#sec-mutating-joins}
+## Uniões básicas {#sec-mutating-joins}
 
-Now that you understand how data frames are connected via keys, we can start using joins to better understand the `flights` dataset.
-dplyr provides six join functions: `left_join()`, `inner_join()`, `right_join()`, `full_join()`, `semi_join()`, and `anti_join().` They all have the same interface: they take a pair of data frames (`x` and `y`) and return a data frame.
-The order of the rows and columns in the output is primarily determined by `x`.
+Agora que você entende como os *data frames* são conectados por meio de chaves (*keys*), podemos começar a usar uniões (*joins*) para entender melhor o conjunto de dados `voos`.
+O pacote dplyr fornece seis funções de união (*join*): `left_join()`, `inner_join()`, `right_join()`, `full_join()`, `semi_join()` e `anti_join().` Todas elas têm a mesma interface: elas pegam dois *data frames* (`x` e `y`) e retornam um *data frame*.
+A ordem das linhas e colunas na saída é determinada principalmente por `x`.
 
-In this section, you'll learn how to use one mutating join, `left_join()`, and two filtering joins, `semi_join()` and `anti_join()`.
-In the next section, you'll learn exactly how these functions work, and about the remaining `inner_join()`, `right_join()` and `full_join()`.
+Nesta seção, você aprenderá como usar uma união mutante (*mutating join*), `left_join()`, e duas uniões de filtragem (*filtering join*), `semi_join()` e `anti_join()`.
+Na próxima seção, você aprenderá exatamente como essas funções funcionam e também sobre as outras funções `inner_join()`, `right_join()` e `full_join()`
 
-### Mutating joins
+### Uniões de mutação
 
-A **mutating join** allows you to combine variables from two data frames: it first matches observations by their keys, then copies across variables from one data frame to the other.
-Like `mutate()`, the join functions add variables to the right, so if your dataset has many variables, you won't see the new ones.
-For these examples, we'll make it easier to see what's going on by creating a narrower dataset with just six variables[^joins-1]:
+Uma **união de mutação** (*mutating join*), permite combinar variáveis ​​de dois *data frames*: primeiro ela combina as observações por suas chaves e depois copia as variáveis ​​de um *data frame* para outro.
+Assim como `mutate()`, as funções de união (*joins*) adicionam variáveis ​​à direita, portanto, se o seu conjunto de dados tiver muitas variáveis, você não verá as novas.
+Para esses exemplos, facilitaremos a visualização do que está acontecendo criando um conjunto de dados mais restrito com apenas seis variáveis[^joins-1]:
 
-[^joins-1]: Remember that in RStudio you can also use `View()` to avoid this problem.
+[^joins-1]: Lembre-se que no RStudio você também pode usar `View()` para evitar este problema
 
 ```{r}
-flights2 <- flights |> 
-  select(year, time_hour, origin, dest, tailnum, carrier)
-flights2
+voos2 <- voos |> 
+  select(ano, data_hora, origem, destino, codigo_cauda, companhia_aerea)
+voos2
 ```
 
-There are four types of mutating join, but there's one that you'll use almost all of the time: `left_join()`.
-It's special because the output will always have the same rows as `x`, the data frame you're joining to[^joins-2].
-The primary use of `left_join()` is to add in additional metadata.
-For example, we can use `left_join()` to add the full airline name to the `flights2` data:
+Existem quatro tipos de uniões de mutação, mas há uma que você usará quase o tempo todo: `left_join()`.
+É especial porque a saída sempre terá as mesmas linhas de `x`, o *data frame* ao qual você está unindo[^joins-2].
+O principal uso de `left_join()` é adicionar metadados adicionais.
+Por exemplo, podemos usar `left_join()` para adicionar o nome completo da companhia aérea aos dados `voos2`:
 
 [^joins-2]: That's not 100% true, but you'll get a warning whenever it isn't.
 
 ```{r}
-flights2 |>
-  left_join(airlines)
+voos2 |>
+  left_join(companhias_aereas)
 ```
 
-Or we could find out the temperature and wind speed when each plane departed:
+Ou poderíamos descobrir a temperatura e a velocidade do vento quando cada avião partiu:
 
 ```{r}
-flights2 |> 
-  left_join(weather |> select(origin, time_hour, temp, wind_speed))
+voos2 |> 
+  left_join(clima |> select(origem, data_hora, temperatura, velocidade_vento))
 ```
 
-Or what size of plane was flying:
+Ou que tamanho de avião estava voando:
 
 ```{r}
-flights2 |> 
-  left_join(planes |> select(tailnum, type, engines, seats))
+voos2 |> 
+  left_join(avioes |> select(codigo_cauda, tipo, motores, assentos))
 ```
 
-When `left_join()` fails to find a match for a row in `x`, it fills in the new variables with missing values.
-For example, there's no information about the plane with tail number `N3ALAA` so the `type`, `engines`, and `seats` will be missing:
+Quando `left_join()` não consegue encontrar uma correspondência para uma linha em `x`, ele preenche as novas variáveis ​​com valores ausentes (*missing values*).
+Por exemplo, não há informações sobre o avião com código de cauda `N3ALAA`, então o `tipo`, os `motores` e os `assentos` ficarão faltando:
 
 ```{r}
-flights2 |> 
-  filter(tailnum == "N3ALAA") |> 
-  left_join(planes |> select(tailnum, type, engines, seats))
+voos2 |> 
+  filter(codigo_cauda == "N3ALAA") |> 
+  left_join(avioes |> select(codigo_cauda, tipo, motores, assentos))
 ```
 
-We'll come back to this problem a few times in the rest of the chapter.
+Voltaremos a esse problema algumas vezes no restante do capítulo.
 
-### Specifying join keys
+### Especificando chaves das uniões
 
-By default, `left_join()` will use all variables that appear in both data frames as the join key, the so called **natural** join.
-This is a useful heuristic, but it doesn't always work.
-For example, what happens if we try to join `flights2` with the complete `planes` dataset?
+Por padrão, `left_join()` usará todas as variáveis ​​que aparecem em ambos os *data frames* como a chave de união, a chamada união **natural** (*natural join*).
+Esta é uma heurística útil, mas nem sempre funciona.
+Por exemplo, o que acontece se tentarmos unir `voos2` com o conjunto de dados completo `avioes`
 
 ```{r}
-flights2 |> 
-  left_join(planes)
+voos2 |> 
+  left_join(avioes)
 ```
 
-We get a lot of missing matches because our join is trying to use `tailnum` and `year` as a compound key.
-Both `flights` and `planes` have a `year` column but they mean different things: `flights$year` is the year the flight occurred and `planes$year` is the year the plane was built.
-We only want to join on `tailnum` so we need to provide an explicit specification with `join_by()`:
+Obtemos muitas correspondências perdidas porque nossa união está tentando usar `codigo_cauda` e `ano` como chave composta.
+Tanto `voos` quanto `avioes` têm uma coluna `ano`, mas significam coisas diferentes: `voos$ano` é o ano em que o voo ocorreu e `avioes$ano` é o ano em que o avião foi construído.
+Queremos unir usando apenas `codigo_cauda`, então precisamos fornecer uma especificação explícita com `join_by()`:
 
 ```{r}
-flights2 |> 
-  left_join(planes, join_by(tailnum))
+voos2 |> 
+  left_join(avioes, join_by(codigo_cauda))
 ```
 
-Note that the `year` variables are disambiguated in the output with a suffix (`year.x` and `year.y`), which tells you whether the variable came from the `x` or `y` argument.
-You can override the default suffixes with the `suffix` argument.
+Observe que as variáveis ​​`ano` são desambiguadas na saída com um sufixo (`ano.x` e `ano.y`), que informa se a variável veio do argumento `x` ou `y`.
+Você pode substituir os sufixos padrão pelo argumento `suffix`.
 
-`join_by(tailnum)` is short for `join_by(tailnum == tailnum)`.
-It's important to know about this fuller form for two reasons.
-Firstly, it describes the relationship between the two tables: the keys must be equal.
-That's why this type of join is often called an **equi join**.
-You'll learn about non-equi joins in @sec-non-equi-joins.
+`join_by(codigo_cauda)` é a abreviação de `join_by(codigo_cauda == codigo_cauda)`.
+É importante conhecer essa forma mais completa por dois motivos.
+Em primeiro lugar, descreve a relação entre as duas tabelas: as chaves devem ser iguais.
+É por isso que esse tipo de junção costuma ser chamado de **união equivalente** (*equi join*).
+Você aprenderá sobre uniões não equivalentes (*non-equi join*) na @sec-non-equi-joins.
 
-Secondly, it's how you specify different join keys in each table.
-For example, there are two ways to join the `flight2` and `airports` table: either by `dest` or `origin`:
+Em segundo lugar, é como você especifica diferentes chaves de união em cada tabela.
+Por exemplo, existem duas maneiras de unir as tabelas `voos2` e `aeroportos`: por `destino` ou `origem`:
 
 ```{r}
-flights2 |> 
-  left_join(airports, join_by(dest == faa))
+voos2 |> 
+  left_join(aeroportos, join_by(destino == codigo_aeroporto))
 
-flights2 |> 
-  left_join(airports, join_by(origin == faa))
+voos2 |> 
+  left_join(aeroportos, join_by(origem == codigo_aeroporto))
 ```
 
-In older code you might see a different way of specifying the join keys, using a character vector:
+Em códigos mais antigos, você pode ver uma maneira diferente de especificar as chaves de união, usando um vetor de caracteres:
 
--   `by = "x"` corresponds to `join_by(x)`.
--   `by = c("a" = "x")` corresponds to `join_by(a == x)`.
+-   `by = "x"` corresponde a `join_by(x)`.
+-   `by = c("a" = "x")` corresponde a `join_by(a == x)`.
 
-Now that it exists, we prefer `join_by()` since it provides a clearer and more flexible specification.
+Agora que existe, preferimos `join_by()` pois fornece uma especificação mais clara e flexível.
 
-`inner_join()`, `right_join()`, `full_join()` have the same interface as `left_join()`.
-The difference is which rows they keep: left join keeps all the rows in `x`, the right join keeps all rows in `y`, the full join keeps all rows in either `x` or `y`, and the inner join only keeps rows that occur in both `x` and `y`.
-We'll come back to these in more detail later.
+`inner_join()`, `right_join()`, `full_join()` têm a mesma interface que `left_join()`.
+A diferença é quais linhas elas mantêm: a *left join* mantém todas as linhas em `x`, a *right join* mantém todas as linhas em `y`, a *full join* mantém todas as linhas em `x` ou `y`, e a *inner join* mantém apenas as linhas que ocorrem em `x` e `y`.
+Voltaremos a isso com mais detalhes posteriormente.
 
-### Filtering joins
+### Uniões de filtragem
 
-As you might guess the primary action of a **filtering join** is to filter the rows.
-There are two types: semi-joins and anti-joins.
-**Semi-joins** keep all rows in `x` that have a match in `y`.
-For example, we could use a semi-join to filter the `airports` dataset to show just the origin airports:
+Como você pode imaginar, a ação principal de uma **união de filtragem** (*filtering joins*) é filtrar as linhas.
+Existem dois tipos: semi-união (*semi-join*) e anti-união (*anti-join*).
+**Semi-união** (*semi-join*) mantêm todas as linhas em `x` que correspondem a `y`.
+Por exemplo, poderíamos usar um *semi-join* para filtrar o conjunto de dados `aeroportos` para mostrar apenas os aeroportos de origem:
 
 ```{r}
-airports |> 
-  semi_join(flights2, join_by(faa == origin))
+aeroportos |> 
+  semi_join(aeroportos, join_by(codigo_aeroporto == origem))
 ```
 
-Or just the destinations:
+Ou apenas de destino:
 
 ```{r}
-airports |> 
-  semi_join(flights2, join_by(faa == dest))
+aeroportos |> 
+  semi_join(aeroportos, join_by(codigo_aeroporto == destino))
 ```
 
-**Anti-joins** are the opposite: they return all rows in `x` that don't have a match in `y`.
-They're useful for finding missing values that are **implicit** in the data, the topic of @sec-missing-implicit.
-Implicitly missing values don't show up as `NA`s but instead only exist as an absence.
-For example, we can find rows that are missing from `airports` by looking for flights that don't have a matching destination airport:
+**Anti-união** (*anti-join*) é o oposto: ela retorno todas as linha em `x` que não possuem correspondência em `y`.
+Eles são úteis para encontrar valores ausentes (*missing values*) que estão **implícitos** nos dados, o tópico tratado no @sec-missing-implicit.
+Valores implicitamente ausentes não aparecem como `NA`s, mas existem apenas como uma ausência.
+Por exemplo, podemos encontrar linhas que estão faltando em `aeroportos` procurando voos que não tenham um aeroporto de destino correspondente.
 
 ```{r}
 flights2 |> 
@@ -342,89 +342,89 @@ flights2 |>
 Or we can find which `tailnum`s are missing from `planes`:
 
 ```{r}
-flights2 |>
-  anti_join(planes, join_by(tailnum)) |> 
-  distinct(tailnum)
+voos2 |>
+  anti_join(avioes, join_by(codigo_cauda)) |> 
+  distinct(codigo_cauda)
 ```
 
-### Exercises
+### Exercícios
 
-1.  Find the 48 hours (over the course of the whole year) that have the worst delays.
-    Cross-reference it with the `weather` data.
-    Can you see any patterns?
+1.  Encontre as 48 horas (ao longo do ano) que apresentam os piores atrasos.
+    Faça referência cruzada com os dados `clima`.
+    Você consegue ver algum padrão?
 
-2.  Imagine you've found the top 10 most popular destinations using this code:
+2.  Imagine que você encontrou os 10 destinos mais populares usando este código:
 
     ```{r}
-    top_dest <- flights2 |>
-      count(dest, sort = TRUE) |>
+    top_destinos <- voos2 |>
+      count(destino, sort = TRUE) |>
       head(10)
     ```
 
-    How can you find all flights to those destinations?
+    Como você pode encontrar todos os voos para esses destinos?
 
-3.  Does every departing flight have corresponding weather data for that hour?
+3.  Cada voo de saída possui dados de clima correspondentes para aquela hora??
 
-4.  What do the tail numbers that don't have a matching record in `planes` have in common?
-    (Hint: one variable explains \~90% of the problems.)
+4.  O que os código de cauda que não possuem um registro correspondente em `avioes` têm em comum?
+    (Dica: uma variável explica cerca de 90% dos problemas.)
 
-5.  Add a column to `planes` that lists every `carrier` that has flown that plane.
-    You might expect that there's an implicit relationship between plane and airline, because each plane is flown by a single airline.
-    Confirm or reject this hypothesis using the tools you've learned in previous chapters.
+5.  Adicione uma coluna a `avioes` que liste todas as `companhia_aereas` que voaram naquele avião.
+    Você poderia esperar que exista uma relação implícita entre avião e companhia aérea, porque cada avião é pilotado por uma única companhia aérea.
+    Confirme ou rejeite esta hipótese usando as ferramentas que você aprendeu nos capítulos anteriores.
 
-6.  Add the latitude and the longitude of the origin *and* destination airport to `flights`.
-    Is it easier to rename the columns before or after the join?
+6.  Adicione a latitude e a longitude do aeroporto de origem *e* de destino a `voos`.
+    É mais fácil renomear as colunas antes ou depois da união (*join*)?
 
-7.  Compute the average delay by destination, then join on the `airports` data frame so you can show the spatial distribution of delays.
-    Here's an easy way to draw a map of the United States:
+7.  Calcule o atraso médio por destino e, em seguida, una-o ao *data frame* `aeroportos` para poder mostrar a distribuição espacial dos atrasos.
+    Esta é uma maneira fácil de desenhar um mapa dos Estados Unidos:
 
     ```{r}
     #| eval: false
 
-    airports |>
-      semi_join(flights, join_by(faa == dest)) |>
-      ggplot(aes(x = lon, y = lat)) +
+    aeroportos |>
+      semi_join(voos, join_by(codigo_aeroporto == destino)) |>
+      ggplot(aes(x = longitude, y = latitude)) +
         borders("state") +
         geom_point() +
         coord_quickmap()
     ```
 
-    You might want to use the `size` or `color` of the points to display the average delay for each airport.
+    Você pode querer usar o `tamanho` ou a `cor` dos pontos para exibir o atraso médio de cada aeroporto.
 
-8.  What happened on June 13 2013?
-    Draw a map of the delays, and then use Google to cross-reference with the weather.
+8.  O que aconteceu em 13 de junho de 2013?
+    Desenhe um mapa dos atrasos e use o Google para fazer referência cruzada com o clima.
 
     ```{r}
     #| eval: false
     #| include: false
 
-    worst <- filter(flights, !is.na(dep_time), month == 6, day == 13)
-    worst |>
-      group_by(dest) |>
-      summarize(delay = mean(arr_delay), n = n()) |>
+    piores <- filter(voos, !is.na(horario_saida), mes == 6, dia == 13)
+    piores |>
+      group_by(destino) |>
+      summarize(atraso = mean(atraso_chegada), n = n()) |>
       filter(n > 5) |>
-      inner_join(airports, join_by(dest == faa)) |>
-      ggplot(aes(x = lon, y = lat)) +
+      inner_join(aeroportos, join_by(destino == codigo_aeroporto)) |>
+      ggplot(aes(x = longitude, y = latitude)) +
         borders("state") +
-        geom_point(aes(size = n, color = delay)) +
+        geom_point(aes(size = n, color = atraso)) +
         coord_quickmap()
     ```
 
-## How do joins work?
+## Como as uniões funcionam?
 
-Now that you've used joins a few times it's time to learn more about how they work, focusing on how each row in `x` matches rows in `y`.
-We'll begin by introducing a visual representation of joins, using the simple tibbles defined below and shown in @fig-join-setup.
-In these examples we'll use a single key called `key` and a single value column (`val_x` and `val_y`), but the ideas all generalize to multiple keys and multiple values.
+Agora que você já usou uniões (*joins*) algumas vezes, é hora de aprender mais sobre como eles funcionam, focando em como cada linha em `x` corresponde às linhas em `y`.
+Começaremos apresentando uma representação visual de uniões, usando os *tibbles* simples definidos abaixo e mostrados na @fig-join-setup.
+Nestes exemplos usaremos uma única chave chamada `chave` e uma única coluna de valor (`val_x` e `val_y`), mas todas as ideias se generalizam para múltiplas chaves e múltiplos valores.
 
 ```{r}
 x <- tribble(
-  ~key, ~val_x,
+  ~chave, ~val_x,
      1, "x1",
      2, "x2",
      3, "x3"
 )
 y <- tribble(
-  ~key, ~val_y,
+  ~chave, ~val_y,
      1, "y1",
      2, "y2",
      4, "y3"
@@ -436,217 +436,217 @@ y <- tribble(
 #| echo: false
 #| out-width: ~
 #| fig-cap: |
-#|   Graphical representation of two simple tables. The colored `key`
-#|   columns map background color to key value. The grey columns represent
-#|   the "value" columns that are carried along for the ride. 
+#|   Representação gráfica de duas tabelas simples. A 'chave' colorida`
+#|   colunas mapeiam a cor de fundo para o valor da chave. As colunas cinza representam
+#|   as colunas de "value" que são transportadas durante o passeio. 
 #| fig-alt: |
-#|   x and y are two data frames with 2 columns and 3 rows, with contents
-#|   as described in the text. The values of the keys are colored:
-#|   1 is green, 2 is purple, 3 is orange, and 4 is yellow.
+#|   x e y são dois data frames com 2 colunas e 3 linhas, com conteúdo
+#|   conforme descrito no texto. Os valores das chaves são coloridos:
+#|   1 é verde, 2 é roxo, 3 é laranja e 4 é amarelo.
 
 knitr::include_graphics("diagrams/join/setup.png", dpi = 270)
 ```
 
-@fig-join-setup2 introduces the foundation for our visual representation.
-It shows all potential matches between `x` and `y` as the intersection between lines drawn from each row of `x` and each row of `y`.
-The rows and columns in the output are primarily determined by `x`, so the `x` table is horizontal and lines up with the output.
+A @fig-join-setup2 apresenta a base para nossa representação visual
+Ele mostra todas as correspondências potenciais entre `x` e `y` como a interseção entre as linhas desenhadas de cada linha de `x` e cada linha de `y`..
+As linhas e colunas na saída são determinadas principalmente por `x`, então a tabela `x` é horizontal e se alinha com a saída.
 
 ```{r}
 #| label: fig-join-setup2
 #| echo: false
 #| out-width: ~
 #| fig-cap: | 
-#|   To understand how joins work, it's useful to think of every possible
-#|   match. Here we show that with a grid of connecting lines.
+#|   TPara entender como funcionam as junções, é útil pensar em todos os possíveis
+#|   correspondências. Aqui mostramos isso com uma grade (grid) de linhas de conexão.
 #| fig-alt: |
-#|   x and y are placed at right-angles, with horizonal lines extending 
-#|   from x and vertical lines extending from y. There are 3 rows in x and 
-#|   3 rows in y, which leads to nine intersections representing nine
-#|   potential matches.
+#|   x e y são colocados em ângulos retos, com linhas horizontais estendendo-se 
+#|   de x e linhas verticais que se estendem de y. Existem 3 linhas em x e 
+#|   3 linhas em y, o que leva a nove interseções representando nove
+#|   possíveis correspondências.
 
 knitr::include_graphics("diagrams/join/setup2.png", dpi = 270)
 ```
 
-To describe a specific type of join, we indicate matches with dots.
-The matches determine the rows in the output, a new data frame that contains the key, the x values, and the y values.
-For example, @fig-join-inner shows an inner join, where rows are retained if and only if the keys are equal.
+Para descrever um tipo específico de união, indicamos correspondências com pontos.
+As correspondências determinam as linhas na saída, um novo *data frame* que contém a chave (*key*), os valores (*values*) x e os valores y.
+Por exemplo, a @fig-join-inner mostra uma união interna (*inner join*), onde as linhas são retidas se e somente se as chaves forem iguais.
 
 ```{r}
 #| label: fig-join-inner
 #| echo: false
 #| out-width: ~
 #| fig-cap: |
-#|   An inner join matches each row in `x` to the row in `y` that has the
-#|   same value of `key`. Each match becomes a row in the output.
+#|   Uma união interna combina cada linha em `x` com a linha em `y` que tem o
+#|   mesmo valor de `chave`. Cada correspondência se torna uma linha na saída.
 #| fig-alt: |
-#|   x and y are placed at right-angles with lines forming a grid of
-#|   potential matches. Keys 1 and 2 appear in both x and y, so we
-#|   get a match, indicated by a dot. Each dot corresponds to a row
-#|   in the output, so the resulting joined data frame has two rows.
+#|   x e y são colocados em ângulos retos com linhas formando uma grade de
+#|   possíveis correspondências. As chaves 1 e 2 aparecem em x e y, então
+#|   obtenha uma correspondência, indicada por um ponto. Cada ponto corresponde a uma linha
+#|   na saída, portanto, o data frame unido resultante terá duas linhass.
 
 knitr::include_graphics("diagrams/join/inner.png", dpi = 270)
 ```
 
-We can apply the same principles to explain the **outer joins**, which keep observations that appear in at least one of the data frames.
-These joins work by adding an additional "virtual" observation to each data frame.
-This observation has a key that matches if no other key matches, and values filled with `NA`.
-There are three types of outer joins:
+Podemos aplicar os mesmos princípios para explicar as **uniões externas** (*outer joins*), que mantêm observações que aparecem em pelo menos um dos *data frames*.
+Essas uniões funcionam adicionando uma observação "virtual" a cada *data frame*.
+Esta observação tem uma chave que corresponde se nenhuma outra chave corresponder e valores preenchidos com `NA`.
+Existem três tipos de uniões externas:
 
--   A **left join** keeps all observations in `x`, @fig-join-left.
-    Every row of `x` is preserved in the output because it can fall back to matching a row of `NA`s in `y`.
+-   Uma **união esquerda** (*left join*) mantém todas as observações em `x`, @fig-join-left.
+    Cada linha de `x` é preservada na saída porque pode voltar a corresponder a uma linha de `NA`s em `y`.
 
     ```{r}
     #| label: fig-join-left
     #| echo: false
     #| out-width: ~
     #| fig-cap: | 
-    #|   A visual representation of the left join where every row in `x`
-    #|   appears in the output.
+    #|   Uma representação visual da união esquerda onde cada linha em `x`
+    #|   aparece na saída.
     #| fig-alt: |
-    #|   Compared to the previous diagram showing an inner join, the y table
-    #|   gets a new virtual row containin NA that will match any row in x
-    #|   that didn't otherwise match. This means that the output now has
-    #|   three rows. For key = 3, which matches this virtual row, val_y takes
-    #|   value NA.
+    #|   Em comparação com o diagrama anterior que mostra uma união interna, a tabela y
+    #|   obtém uma nova linha virtual contendo NA que corresponderá a qualquer linha em x
+    #|   que de outra forma não correspondia. Isso significa que a saída agora tem
+    #|   três linhas. Para chave = 3, que corresponde a esta linha virtual, val_y leva
+    #|   valor NA.
 
     knitr::include_graphics("diagrams/join/left.png", dpi = 270)
     ```
 
--   A **right join** keeps all observations in `y`, @fig-join-right.
-    Every row of `y` is preserved in the output because it can fall back to matching a row of `NA`s in `x`.
-    The output still matches `x` as much as possible; any extra rows from `y` are added to the end.
+-   Uma **união direita** (*right join*) mantém todas as observações em `y`, @fig-join-right.
+    Cada linha de `y` é preservada na saída porque pode voltar a corresponder a uma linha de `NA`s em `x`.
+    A saída ainda corresponde a `x` tanto quanto possível; quaisquer linhas extras de `y` são adicionadas ao final.
 
     ```{r}
     #| label: fig-join-right
     #| echo: false
     #| out-width: ~
     #| fig-cap: | 
-    #|   A visual representation of the right join where every row of `y` 
-    #|   appears in the output. 
+    #|   Uma representação visual da união direita onde cada linha de `y` 
+    #|   aparece na saída. 
     #| fig-alt: |
-    #|   Compared to the previous diagram showing an left join, the x table
-    #|   now gains a virtual row so that every row in y gets a match in x.
-    #|   val_x contains NA for the row in y that didn't match x.
+    #|   Comparado ao diagrama anterior mostrando uma união à esquerda, a tabela x
+    #|   agora ganha uma linha virtual para que cada linha em y corresponda a x.
+    #|   val_x contém NA para a linha em y que não corresponde a x.
 
     knitr::include_graphics("diagrams/join/right.png", dpi = 270)
     ```
 
--   A **full join** keeps all observations that appear in `x` or `y`, @fig-join-full.
-    Every row of `x` and `y` is included in the output because both `x` and `y` have a fall back row of `NA`s.
-    Again, the output starts with all rows from `x`, followed by the remaining unmatched `y` rows.
+-   Uma **união completa** (*full join*) mantém todas as observações que aparecem em `x` ou `y`, @fig-join-full.
+    Cada linha de `x` e `y` é incluída na saída porque ambos `x` e `y` têm uma linha alternativa de `NA`s.
+    Novamente, a saída começa com todas as linhas de `x`, seguidas pelas linhas `y` restantes sem correspondência.
 
     ```{r}
     #| label: fig-join-full
     #| echo: false
     #| out-width: ~
     #| fig-cap: | 
-    #|   A visual representation of the full join where every row in `x`
-    #|   and `y` appears in the output.
+    #|   Uma representação visual da união completa onde cada linha em `x`
+    #|   e `y` aparece na saída.
     #| fig-alt: |
-    #|   Now both x and y have a virtual row that always matches.
-    #|   The result has 4 rows: keys 1, 2, 3, and 4 with all values 
-    #|   from val_x and val_y, however key 2, val_y and key 4, val_x are NAs
-    #|   since those keys don't have a match in the other data frames.
+    #|   Agora, x e y têm uma linha virtual que sempre corresponde.
+    #|   O resultado tem 4 linhas: chaves 1, 2, 3 e 4 com todos os valores 
+    #|   de val_x e val_y, porém chave 2, val_y e chave 4, val_x são NAs
+    #|   já que essas chaves não correspondem aos outros data frames.
 
     knitr::include_graphics("diagrams/join/full.png", dpi = 270)
     ```
 
-Another way to show how the types of outer join differ is with a Venn diagram, as in @fig-join-venn.
-However, this is not a great representation because while it might jog your memory about which rows are preserved, it fails to illustrate what's happening with the columns.
+Outra maneira de mostrar como os tipos de uniões externas (*outer joins*) diferem é com um diagrama de Venn, como na @fig-join-venn.
+No entanto, esta não é uma boa representação porque, embora possa refrescar sua memória sobre quais linhas são preservadas, ela não ilustra o que está acontecendo com as colunas.
 
 ```{r}
 #| label: fig-join-venn
 #| echo: false
 #| out-width: ~
 #| fig-cap: |
-#|   Venn diagrams showing the difference between inner, left, right, and
-#|   full joins.
+#|   Diagramas de Venn mostrando a diferença entre uniões internas, esquerda, direita e 
+#|   completa.
 #| fig-alt: |
-#|   Venn diagrams for inner, full, left, and right joins. Each join
-#|   represented with two intersecting circles representing data frames x
-#|   and y, with x on the right and y on the left. Shading indicates the
-#|   result of the join. 
+#|   Diagramas de Venn para uniões internas, completas, esquerda e direita. Cada união
+#|   representado com dois círculos que se cruzam representando data frame x
+#|   e y, com x à direita e y à esquerda. O sombreamento indica o
+#|   resultado da união. 
 #|
-#|   Inner join: the intersection is shaded. 
-#|   Full join: Everything is shaded. 
-#|   Left join: All of x is shaded.
-#|   Right join: All of y is shaded.
+#|   União interna: a interseção está sombreada. 
+#|   União completa: Tudo está sombreado. 
+#|   União esquerda: Tudo em x está sombreado.
+#|   União direita: Tudo em y está sombreado.
 
 knitr::include_graphics("diagrams/join/venn.png", dpi = 270)
 ```
 
-The joins shown here are the so-called **equi** **joins**, where rows match if the keys are equal.
-Equi joins are the most common type of join, so we'll typically omit the equi prefix, and just say "inner join" rather than "equi inner join".
-We'll come back to non-equi joins in @sec-non-equi-joins.
+As uniões mostradas até aqui são chamadas **uniões equivalentes** (*equi joins*), onde as linhas correspondem se as chaves forem iguais.
+Uniões equivalentes (*equi joins*) são o tipo mais comum de união, então normalmente omitiremos o prefixo equi e apenas diremos "união interna" (*inner join*) em vez de "união interna equivalente" (*equi inner join*).
+Voltaremos às unão não-equivalentes (*non-equi joins*) no @sec-non-equi-joins.
 
-### Row matching
+### Correspondências de linhas
 
-So far we've explored what happens if a row in `x` matches zero or one row in `y`.
-What happens if it matches more than one row?
-To understand what's going let's first narrow our focus to the `inner_join()` and then draw a picture, @fig-join-match-types.
+Até agora, exploramos o que acontece se uma linha em `x` corresponder a zero ou a uma linha em `y`.
+O que acontece se corresponder a mais de uma linha?
+Para entender o que está acontecendo, vamos primeiro restringir nosso foco à função `inner_join()` e então fazer um desenho, @fig-join-match-types.
 
 ```{r}
 #| label: fig-join-match-types
 #| echo: false
 #| out-width: ~
 #| fig-cap: | 
-#|   The three ways a row in `x` can match. `x1` matches
-#|   one row in `y`, `x2` matches two rows in `y`, `x3` matches
-#|   zero rows in y. Note that while there are three rows in
-#|   `x` and three rows in the output, there isn't a direct
-#|   correspondence between the rows.
+#|   As três maneiras pelas quais uma linha em `x` pode corresponder. `x1` corresponde
+#|   uma linha em `y`, `x2` corresponde a duas linhas em `y`, `x3` corresponde
+#|   zero linhas em y. Observe que embora existam três linhas em
+#|   `x` e três linhas na saída, não há um direta
+#|   correspondência entre as linhas.
 #| fig-alt: |
-#|   A join diagram where x has key values 1, 2, and 3, and y has
-#|   key values 1, 2, 2. The output has three rows because key 1 matches
-#|   one row, key 2 matches two rows, and key 3 matches zero rows.
+#|   Um diagrama de união onde x tem chaves-valores 1, 2 e 3, e y tem
+#|   chaves-valores 1, 2, 2. A saída tem três linhas porque a chave 1 corresponde
+#|   uma linha, a chave 2 corresponde a duas linhas e a chave 3 corresponde a zero linhas.
 
 knitr::include_graphics("diagrams/join/match-types.png", dpi = 270)
 ```
 
-There are three possible outcomes for a row in `x`:
+Existem três resultados possíveis para uma linha em `x`::
 
--   If it doesn't match anything, it's dropped.
--   If it matches 1 row in `y`, it's preserved.
--   If it matches more than 1 row in `y`, it's duplicated once for each match.
+-   Se não corresponder a nada, é descartado.
+-   Se corresponder a 1 linha em `y`, é preservado.
+-   Se corresponder a mais de 1 linha em `y`, será duplicado uma vez para cada correspondência.
 
-In principle, this means that there's no guaranteed correspondence between the rows in the output and the rows in `x`, but in practice, this rarely causes problems.
-There is, however, one particularly dangerous case which can cause a combinatorial explosion of rows.
-Imagine joining the following two tables:
+Em princípio, isso significa que não há correspondência garantida entre as linhas na saída e as linhas em `x`, mas na prática, isso raramente causa problemas.
+Existe, no entanto, um caso particularmente perigoso que pode causar uma explosão combinatória de linhas.
+Imagine fazer a união (*join*) das duas tabelas a seguir:
 
 ```{r}
-df1 <- tibble(key = c(1, 2, 2), val_x = c("x1", "x2", "x3"))
-df2 <- tibble(key = c(1, 2, 2), val_y = c("y1", "y2", "y3"))
+df1 <- tibble(chave = c(1, 2, 2), val_x = c("x1", "x2", "x3"))
+df2 <- tibble(chave = c(1, 2, 2), val_y = c("y1", "y2", "y3"))
 ```
 
-While the first row in `df1` only matches one row in `df2`, the second and third rows both match two rows.
-This is sometimes called a `many-to-many` join, and will cause dplyr to emit a warning:
+Enquanto a primeira linha em `df1` corresponde apenas a uma linha em `df2`, a segunda e a terceira linhas correspondem a duas linhas.
+Isso às vezes é chamado de relacionamento `muitos para muitos` (*many-to-many relationship*) e fará com que o dplyr emita um aviso:
 
 ```{r}
 df1 |> 
-  inner_join(df2, join_by(key))
+  inner_join(df2, join_by(chave))
 ```
 
-If you are doing this deliberately, you can set `relationship = "many-to-many"`, as the warning suggests.
+Se você estiver fazendo isso deliberadamente, você pode definir `relationship = "many-to-many"`, como o aviso sugere.
 
-### Filtering joins
+### Uniões de filtragem
 
-The number of matches also determines the behavior of the filtering joins.
-The semi-join keeps rows in `x` that have one or more matches in `y`, as in @fig-join-semi.
-The anti-join keeps rows in `x` that match zero rows in `y`, as in @fig-join-anti.
-In both cases, only the existence of a match is important; it doesn't matter how many times it matches.
-This means that filtering joins never duplicate rows like mutating joins do.
+O número de correspondências também determina o comportamento das uniões de filtragem (*filtrering joins*).
+A semi-união (*semi-join*) mantém linhas em `x` que possuem uma ou mais correspondências em `y`, como em @fig-join-semi.
+A anti-união **anti-join*) mantém linhas em `x` que correspondem a zero linhas em `y`, como na @ fig-join-anti.
+Em ambos os casos, apenas a existência de uma correspondência é importante; não importa quantas vezes corresponda.
+Isso significa que as uniões de filtragem (*filtering joins*) nunca duplicam linhas como as uniões de mutação (*mutating joins*) fazem.
 
 ```{r}
 #| label: fig-join-semi
 #| echo: false
 #| out-width: null
 #| fig-cap: |
-#|   In a semi-join it only matters that there is a match; otherwise
-#|   values in `y` don't affect the output.
+#|   Em uma semi-união (*Semi-join*) só importa que haja uma correspondência; ou seja, `
+#|   valores em `y` não afetam a saída.
 #| fig-alt: |
-#|   A join diagram with old friends x and y. In a semi join, only the 
-#|   presence of a match matters so the output contains the same columns
-#|   as x.
+#|   Um diagrama de união com velhos amigos x e y. Em uma semi-união, apenas o 
+#|   a presença de uma correspondência é importante, então a saída contém as mesmas colunas
+#|   como x.
 
 knitr::include_graphics("diagrams/join/semi.png", dpi = 270)
 ```
@@ -656,119 +656,119 @@ knitr::include_graphics("diagrams/join/semi.png", dpi = 270)
 #| echo: false
 #| out-width: null
 #| fig-cap: |
-#|   An anti-join is the inverse of a semi-join, dropping rows from `x`
-#|   that have a match in `y`.
+#|   Uma anti-união **anti-join*) é o inverso de uma semi-união (*semi-join*), eliminando linhas de `x`
+#|   que têm uma correspondência em `y`.
 #| fig-alt: |
-#|   An anti-join is the inverse of a semi-join so matches are drawn with
-#|   red lines indicating that they will be dropped from the output.
+#|   Uma anti-união é o inverso de uma semi-união, então as correspondências são desenhadas com
+#|   linhas vermelhas indicando que elas serão eliminadas da saída.
 
 knitr::include_graphics("diagrams/join/anti.png", dpi = 270)
 ```
 
-## Non-equi joins {#sec-non-equi-joins}
+## Uniões não-equivalentes {#sec-non-equi-joins}
 
-So far you've only seen equi joins, joins where the rows match if the `x` key equals the `y` key.
-Now we're going to relax that restriction and discuss other ways of determining if a pair of rows match.
+Até agora você só viu uniões equivalentes (*equi joins*), uniões onde as linhas correspondem se a chave `x` for igual à chave `y`.
+Agora vamos relaxar essa restrição e discutir outras maneiras de determinar se um par de linhas se corresponde.
 
-But before we can do that, we need to revisit a simplification we made above.
-In equi joins the `x` keys and `y` are always equal, so we only need to show one in the output.
-We can request that dplyr keep both keys with `keep = TRUE`, leading to the code below and the re-drawn `inner_join()` in @fig-inner-both.
+Mas antes de podermos fazer isso, precisamos rever uma simplificação que fizemos acima.
+Nas uniões equivalentes, as chaves `x` e `y` são sempre iguais, então só precisamos mostrar uma na saída.
+Podemos solicitar que dplyr mantenha ambas as chaves com `keep = TRUE`, o que leva ao código abaixo e ao `inner_join()` redesenhado na @ fig-inner-both.
 
 ```{r}
-x |> inner_join(y, join_by(key == key), keep = TRUE)
+x |> inner_join(y, join_by(chave == chave), keep = TRUE)
 ```
 
 ```{r}
 #| label: fig-inner-both
 #| fig-cap: |
-#|   An inner join showing both `x` and `y` keys in the output.
+#|   Uma união interna (*inner join*) monstrando tanto a chave `x` quanto a chave `y` na saída.
 #| fig-alt: |
-#|   A join diagram showing an inner join betwen x and y. The result
-#|   now includes four columns: key.x, val_x, key.y, and val_y. The
-#|   values of key.x and key.y are identical, which is why we usually
-#|   only show one.
+#|   Um diagrama de união mostrando uma união interna (*inner join*) entre x e y. O resultado
+#|   agora inclui quatro colunas: chave.x, val_x, chave.y e val_y. Os
+#|   valores de chave.x e chave.y são idênticos, e é por isso que geralmente
+#|   mostre apenas um.
 #| echo: false
 #| out-width: ~
 
 knitr::include_graphics("diagrams/join/inner-both.png", dpi = 270)
 ```
 
-When we move away from equi joins we'll always show the keys, because the key values will often be different.
-For example, instead of matching only when the `x$key` and `y$key` are equal, we could match whenever the `x$key` is greater than or equal to the `y$key`, leading to @fig-join-gte.
-dplyr's join functions understand this distinction equi and non-equi joins so will always show both keys when you perform a non-equi join.
+Quando nos afastamos das uniões equivalentes (*equi joins*), sempre mostraremos as chaves (*keys*), porque os valores das chaves geralmente serão diferentes.
+Por exemplo, em vez de combinar apenas quando `x$chave` e `y$chave` forem iguais, poderíamos combinar sempre que `x$chave` for maior ou igual a `y$chave`, levando a @fig -junte-gte.
+As funções de união do pacote dplyr entendem essa distinção entre uniões equivalentes (*equi joins*) e uniões não-equivalentes (*non-equi joins*), portanto sempre mostrarão ambas as chaves quando você realizar uma união não-equivalente.
 
 ```{r}
 #| label: fig-join-gte
 #| echo: false
 #| fig-cap: |
-#|   A non-equi join where the `x` key must be greater than or equal to 
-#|   the `y` key. Many rows generate multiple matches.
+#|   Uma unão não-equivalente onde a chave `x` deve ser maior ou igual a 
+#|   chave em `y`. Muitas linhas geram múltiplas correspondências.
 #| fig-alt: |
-#|   A join diagram illustrating join_by(key >= key). The first row
-#|   of x matches one row of y and the second and thirds rows each match
-#|   two rows. This means the output has five rows containing each of the 
-#|   following (key.x, key.y) pairs: (1, 1), (2, 1), (2, 2), (3, 1),
+#|   Um diagrama de união ilustrando join_by(chave >= chave). A primeira linha
+#|   de x corresponde a uma linha de y e a segunda e terceira linhas correspondem
+#|   duas linhas. Isso significa que a saída tem cinco linhas contendo cada um dos 
+#|   seguintes pares (chave.x, chave.y): (1, 1), (2, 1), (2, 2), (3, 1),
 #|   (3, 2).
 knitr::include_graphics("diagrams/join/gte.png", dpi = 270)
 ```
 
-Non-equi join isn't a particularly useful term because it only tells you what the join is not, not what it is. dplyr helps by identifying four particularly useful types of non-equi join:
+União não-equivalente (*non-equi join*) não é um termo particularmente útil porque apenas informa o que a união não é, e não o que é. O dplyr ajuda a identificar quatro tipos particularmente úteis de uniões não-equivalentes:
 
--   **Cross joins** match every pair of rows.
--   **Inequality joins** use `<`, `<=`, `>`, and `>=` instead of `==`.
--   **Rolling joins** are similar to inequality joins but only find the closest match.
--   **Overlap joins** are a special type of inequality join designed to work with ranges.
+-   **Uniões cruzadas** (*cross joins*) correspondem a cada par de linhas.
+-   **Uniões de desigualdades** (*inequality joins*) usam `<`, `<=`, `>` e `>=` em vez de `==`.
+-   **Uniões deslizantes** (*rolling joins*) são semelhantes às junções de desigualdade, mas apenas encontram a correspondência mais próxima.
+-   **Uniões de sobreposições** (*overlap joins*) são um tipo especial de junção de desigualdade projetada para trabalhar com intervalos.
 
 Each of these is described in more detail in the following sections.
 
-### Cross joins
+### Uniões cruzadas
 
-A cross join matches everything, as in @fig-join-cross, generating the Cartesian product of rows.
-This means the output will have `nrow(x) * nrow(y)` rows.
+Uma união cruzada (*cross join*) corresponde a tudo, como na @fig-join-cross, gerando o produto cartesiano de linhas.
+Isso significa que a saída terá linhas `nrow(x) * nrow(y)`.
 
 ```{r}
 #| label: fig-join-cross
 #| echo: false
 #| out-width: ~
 #| fig-cap: |
-#|   A cross join matches each row in `x` with every row in `y`.
+#|   Uma união cruzada combina cada linha em `x` com cada linha em `y`.
 #| fig-alt: |
-#|   A join diagram showing a dot for every combination of x and y.
+#|   Um diagrama de união mostrando um ponto para cada combinação de x e y.
 knitr::include_graphics("diagrams/join/cross.png", dpi = 270)
 ```
 
-Cross joins are useful when generating permutations.
-For example, the code below generates every possible pair of names.
-Since we're joining `df` to itself, this is sometimes called a **self-join**.
-Cross joins use a different join function because there's no distinction between inner/left/right/full when you're matching every row.
+As uniõescruzadas são úteis ao gerar permutações.
+Por exemplo, o código abaixo gera todos os pares possíveis de nomes.
+Como estamos unindo `df` a ele mesmo, isso às vezes é chamado de **auto-união** (*self-join*).
+As uniões cruzadas usam uma função de união diferente porque não há distinção entre interno/esquerdo/direito/completo quando você corresponde a cada linha
 
 ```{r}
 df <- tibble(name = c("John", "Simon", "Tracy", "Max"))
 df |> cross_join(df)
 ```
 
-### Inequality joins
+### Uniões de desigualdades
 
-Inequality joins use `<`, `<=`, `>=`, or `>` to restrict the set of possible matches, as in @fig-join-gte and @fig-join-lt.
+Uniões de desigualdade (*inequality joins*) usam `<`, `<=`, `>=` ou `>` para restringir o conjunto de correspondências possíveis, como na @fig-join-gte e na @fig-join-lt.
 
 ```{r}
 #| label: fig-join-lt
 #| echo: false
 #| out-width: ~
 #| fig-cap: |
-#|   An inequality join where `x` is joined to `y` on rows where the key 
-#|   of `x` is less than the key of `y`. This makes a triangular
-#|   shape in the top-left corner.
+#|   AUma junção de desigualdade onde `x` é unido a `y` nas linhas onde a chave 
+#|   de `x` é menor que a chave de `y`. Isso forma um triângulo
+#|   no canto superior esquerdo.
 #| fig-alt: |
-#|   A diagram depicting an inequality join where a data frame x is joined by 
-#|   a data frame y where the key of x is less than the key of y, resulting 
-#|   in a triangular shape in the top-left corner.
+#|   Um diagrama que descreve uma junção de desigualdade onde um quadro de dados x é unido por 
+#|   um data frame y onde a chave de x é menor que a chave de y, resultando 
+#|   em um triangulo no canto superior esquerdo.
 
 knitr::include_graphics("diagrams/join/lt.png", dpi = 270)
 ```
 
-Inequality joins are extremely general, so general that it's hard to come up with meaningful specific use cases.
-One small useful technique is to use them to restrict the cross join so that instead of generating all permutations, we generate all combinations:
+As uniões de desigualdade são extremamente gerais, tão gerais que é difícil encontrar casos de uso específicos significativos.
+Uma pequena técnica útil é usá-los para restringir a união cruzada de modo que, em vez de gerar todas as permutações, geremos todas as combinações:
 
 ```{r}
 df <- tibble(id = 1:4, name = c("John", "Simon", "Tracy", "Max"))
@@ -776,141 +776,141 @@ df <- tibble(id = 1:4, name = c("John", "Simon", "Tracy", "Max"))
 df |> inner_join(df, join_by(id < id))
 ```
 
-### Rolling joins
+### Uniões deslizantes
 
-Rolling joins are a special type of inequality join where instead of getting *every* row that satisfies the inequality, you get just the closest row, as in @fig-join-closest.
-You can turn any inequality join into a rolling join by adding `closest()`.
-For example `join_by(closest(x <= y))` matches the smallest `y` that's greater than or equal to x, and `join_by(closest(x > y))` matches the biggest `y` that's less than `x`.
+Uniões deslizantes (*rolling joins*) são um tipo especial de uniã0 de desigualdade onde, em vez de obter *todas* as linhas que satisfaçam a desigualdade, você obtém apenas a linha mais próxima, como na @ fig-join-closest.
+Você pode transformar qualquer união de desigualdade em uma união deslizante adicionando a função `closest()`.
+Por exemplo, `join_by(closest(x <= y))` corresponde ao menor `y` que é maior ou igual a x, e `join_by(closest(x > y))` corresponde ao maior `y` que é menor que ` x`
 
 ```{r}
 #| label: fig-join-closest
 #| echo: false
 #| out-width: ~
 #| fig-cap: |
-#|   A rolling join is similar to a greater-than-or-equal inequality join
-#|   but only matches the first value.
+#|   Uma união deslizante é semelhante a uma união de desigualdade maior ou igual
+#|   mas corresponde apenas ao primeiro valor.
 #| fig-alt: |
-#|   A rolling join is a subset of an inequality join so some matches are
-#|   grayed out indicating that they're not used because they're not the 
-#|   "closest".
+#|   Uma união dezlizante é um subconjunto de uma uniçao de desigualdade, portanto algumas correspondências são
+#|   acinzentadas indicando que eles não são usados ​​porque não são os 
+#|   valores "mais próximos".
 knitr::include_graphics("diagrams/join/closest.png", dpi = 270)
 ```
 
-Rolling joins are particularly useful when you have two tables of dates that don't perfectly line up and you want to find (e.g.) the closest date in table 1 that comes before (or after) some date in table 2.
+As uniões deslizantes (*rolling joins*) são particularmente úteis quando você tem duas tabelas de datas que não estão perfeitamente alinhadas e deseja encontrar (por exemplo) a data mais próxima na tabela 1 que vem antes (ou depois) de alguma data na tabela 2.
 
-For example, imagine that you're in charge of the party planning commission for your office.
-Your company is rather cheap so instead of having individual parties, you only have a party once each quarter.
-The rules for determining when a party will be held are a little complex: parties are always on a Monday, you skip the first week of January since a lot of people are on holiday, and the first Monday of Q3 2022 is July 4, so that has to be pushed back a week.
-That leads to the following party days:
+Por exemplo, imagine que você é responsável pela comissão de planejamento de festas do seu escritório.
+Sua empresa é bastante econômica, então, em vez de dar festas individuais, você só dá uma vez a cada trimestre.
+As regras para determinar quando uma festa será realizada são um pouco complexas: as festas são sempre na segunda-feira, você pula a primeira semana de janeiro porque muita gente está de férias, e a primeira segunda-feira do terceiro trimestre de 2022 é 4 de julho (feirado), então isso tem que ser adiado por uma semana.
+Isso leva aos seguintes dias de festa:
 
 ```{r}
-parties <- tibble(
-  q = 1:4,
-  party = ymd(c("2022-01-10", "2022-04-04", "2022-07-11", "2022-10-03"))
+festas <- tibble(
+  trimetre = 1:4,
+  festa = ymd(c("2022-01-10", "2022-04-04", "2022-07-11", "2022-10-03"))
 )
 ```
 
-Now imagine that you have a table of employee birthdays:
+Agora imagine que você tem uma tabela de aniversários de funcionários:
 
 ```{r}
 set.seed(123)
-employees <- tibble(
-  name = sample(babynames::babynames$name, 100),
-  birthday = ymd("2022-01-01") + (sample(365, 100, replace = TRUE) - 1)
+funcionarios <- tibble(
+  nome = sample(dados::bebes$nome, 100),
+  aniversario = ymd("2022-01-01") + (sample(365, 100, replace = TRUE) - 1)
 )
-employees
+funcionarios
 ```
 
-And for each employee we want to find the first party date that comes after (or on) their birthday.
-We can express that with a rolling join:
+E para cada funcionário queremos encontrar a data da primeira festa que ocorre depois (ou no dia) do seu aniversário.
+Podemos expressar isso com uma união deslizante:
 
 ```{r}
-employees |> 
-  left_join(parties, join_by(closest(birthday >= party)))
+funcionarios |> 
+  left_join(festas, join_by(closest(aniversario >= festa)))
 ```
 
-There is, however, one problem with this approach: the folks with birthdays before January 10 don't get a party:
+Há, no entanto, um problema com esta abordagem: quem faz aniversário antes de 10 de janeiro não ganha festa:
 
 ```{r}
-employees |> 
-  anti_join(parties, join_by(closest(birthday >= party)))
+funcionarios |> 
+  anti_join(festas, join_by(closest(aniversario >= festa)))
 ```
 
-To resolve that issue we'll need to tackle the problem a different way, with overlap joins.
+Para resolver esse problema, precisaremos abordar o problema de uma maneira diferente, com uniões de sobreposições (*overlap joins*).
 
-### Overlap joins
+### Uniões de sobreposições
 
-Overlap joins provide three helpers that use inequality joins to make it easier to work with intervals:
+Uniões de sobreposições (*overlap joins*) fornecem três funções de ajuda que usam uniões de desigualdade para facilitar o trabalho com intervalos:
 
--   `between(x, y_lower, y_upper)` is short for `x >= y_lower, x <= y_upper`.
--   `within(x_lower, x_upper, y_lower, y_upper)` is short for `x_lower >= y_lower, x_upper <= y_upper`.
--   `overlaps(x_lower, x_upper, y_lower, y_upper)` is short for `x_lower <= y_upper, x_upper >= y_lower`.
+-   `between(x, y_inferior, y_superior)` é uma abreviação para `x >= y_inferior, x <= y_superior`.
+-   `within(x_inferior, x_superior, y_inferior, y_superior)` é uma abreviação para `x_inferior >= y_inferior, x_superior <= y_superior`.
+-   `overlaps(x_inferior, x_superior, y_inferior, y_superior)` é uma abreviação para `x_inferior <= y_superior, x_superior >= y_inferior`.
 
-Let's continue the birthday example to see how you might use them.
-There's one problem with the strategy we used above: there's no party preceding the birthdays Jan 1-9.
-So it might be better to be explicit about the date ranges that each party spans, and make a special case for those early birthdays:
+Vamos continuar o exemplo do aniversário para ver como você pode usá-los.
+Há um problema com a estratégia que usamos acima: não há festa antes dos aniversários de 1º a 9 de janeiro.
+Portanto, talvez seja melhor ser explícito sobre os intervalos de datas que cada festa abrange e apresentar um caso especial para os aniversários antecipados:
 
 ```{r}
-parties <- tibble(
-  q = 1:4,
-  party = ymd(c("2022-01-10", "2022-04-04", "2022-07-11", "2022-10-03")),
-  start = ymd(c("2022-01-01", "2022-04-04", "2022-07-11", "2022-10-03")),
-  end = ymd(c("2022-04-03", "2022-07-11", "2022-10-02", "2022-12-31"))
+festas <- tibble(
+  trimestre = 1:4,
+  festa = ymd(c("2022-01-10", "2022-04-04", "2022-07-11", "2022-10-03")),
+  inicio = ymd(c("2022-01-01", "2022-04-04", "2022-07-11", "2022-10-03")),
+  fim = ymd(c("2022-04-03", "2022-07-11", "2022-10-02", "2022-12-31"))
 )
-parties
+festas
 ```
 
-Hadley is hopelessly bad at data entry so he also wanted to check that the party periods don't overlap.
-One way to do this is by using a self-join to check if any start-end interval overlap with another:
+O Hadley é terrivelmente ruim na entrada de dados, então ele também queria verificar se os períodos das festas não se sobrepunham.
+Uma maneira de fazer isso é usar uma auto-união (*self-join*) para verificar se algum intervalo inicio-fim se sobrepõe a outro:
 
 ```{r}
-parties |> 
-  inner_join(parties, join_by(overlaps(start, end, start, end), q < q)) |> 
-  select(start.x, end.x, start.y, end.y)
+festas |> 
+  inner_join(festas, join_by(overlaps(inicio, fim, inicio, fim), trimestre < trimestre)) |> 
+  select(inicio.x, fim.x, inicio.y, fim.y)
 ```
 
-Ooops, there is an overlap, so let's fix that problem and continue:
+Ops, há uma sobreposição, então vamos corrigir esse problema e continuar:
 
 ```{r}
-parties <- tibble(
-  q = 1:4,
-  party = ymd(c("2022-01-10", "2022-04-04", "2022-07-11", "2022-10-03")),
-  start = ymd(c("2022-01-01", "2022-04-04", "2022-07-11", "2022-10-03")),
-  end = ymd(c("2022-04-03", "2022-07-10", "2022-10-02", "2022-12-31"))
+festas <- tibble(
+  trimestre = 1:4,
+  festa = ymd(c("2022-01-10", "2022-04-04", "2022-07-11", "2022-10-03")),
+  inicio = ymd(c("2022-01-01", "2022-04-04", "2022-07-11", "2022-10-03")),
+  fim = ymd(c("2022-04-03", "2022-07-10", "2022-10-02", "2022-12-31"))
 )
 ```
 
-Now we can match each employee to their party.
-This is a good place to use `unmatched = "error"` because we want to quickly find out if any employees didn't get assigned a party.
+Agora podemos combinar cada funcionário com seu grupo.
+Este é um bom lugar para usar o argumento `unmatched = "error"`, porque queremos descobrir rapidamente se algum funcionário não foi designado para um grupo.
 
 ```{r}
-employees |> 
-  inner_join(parties, join_by(between(birthday, start, end)), unmatched = "error")
+funcionarios |> 
+  inner_join(festas, join_by(between(aniversario, inicio, fim)), unmatched = "error")
 ```
 
-### Exercises
+### Exercícios
 
-1.  Can you explain what's happening with the keys in this equi join?
-    Why are they different?
+1.  Você pode explicar o que está acontecendo com as chaves (*keys*) nesta união equivalente (*equi join*)?
+    Por que elas são diferentes?
 
     ```{r}
-    x |> full_join(y, join_by(key == key))
+    x |> full_join(y, join_by(chave == chave))
 
-    x |> full_join(y, join_by(key == key), keep = TRUE)
+    x |> full_join(y, join_by(chave == chave), keep = TRUE)
     ```
 
-2.  When finding if any party period overlapped with another party period we used `q < q` in the `join_by()`?
-    Why?
-    What happens if you remove this inequality?
+2.  Ao descobrir se algum período de festa se sobrepôs a outro período de festa, usamos `trimestre < trimestre` em `join_by()`?
+    Por que?
+    O que acontece se você remover essa desigualdade?
 
-## Summary
+## Resumo
 
-In this chapter, you've learned how to use mutating and filtering joins to combine data from a pair of data frames.
-Along the way you learned how to identify keys, and the difference between primary and foreign keys.
-You also understand how joins work and how to figure out how many rows the output will have.
-Finally, you've gained a glimpse into the power of non-equi joins and seen a few interesting use cases.
+Neste capítulo, você aprendeu como usar uniões de mutações (*mutating joins*) e filtragem (*filtering joins*) para combinar dados de dois *data frames*.
+Ao longo do caminho você aprendeu como identificar chaves (*keys*) e a diferença entre chaves primárias (*primary keys*) e estrangeiras (*foreign keys*).
+Você também entende como funcionam as uniões e como descobrir quantas linhas a saída terá.
+Finalmente, você teve uma ideia do poder das uniões não-equivalentes (*non-equi joins*) e viu alguns casos de uso interessantes.
 
-This chapter concludes the "Transform" part of the book where the focus was on the tools you could use with individual columns and tibbles.
-You learned about dplyr and base functions for working with logical vectors, numbers, and complete tables, stringr functions for working with strings, lubridate functions for working with date-times, and forcats functions for working with factors.
+Este capítulo conclui a parte "Transformar" do livro, onde o foco estava nas ferramentas que você poderia usar com colunas e tabelas individuais.
+Você aprendeu sobre o pacote dyplr e suas funções base para trabalhar com vetores lógicos, números e tabelas completas, funções do pacote stringr para trabalhar com strings, funções do pacote lubridate para trabalhar com datas e horários e funções do pacote forcats para trabalhar com fatores.
 
-In the next part of the book, you'll learn more about getting various types of data into R in a tidy form.
+Na próxima parte do livro, você aprenderá mais sobre como colocar vários tipos de dados em R de uma forma organizada (*tidy*).

--- a/joins.qmd
+++ b/joins.qmd
@@ -505,7 +505,7 @@ Existem três tipos de uniões externas:
     #|   Uma representação visual da união esquerda onde cada linha em `x`
     #|   aparece na saída.
     #| fig-alt: |
-    #|   Em comparação com o diagrama anterior que mostra uma união interna, a tabela y
+    #|   Em comparação com o diagrama anterior que mostra uma união interna (*inner join*), a tabela y
     #|   obtém uma nova linha virtual contendo NA que corresponderá a qualquer linha em x
     #|   que de outra forma não correspondia. Isso significa que a saída agora tem
     #|   três linhas. Para chave = 3, que corresponde a esta linha virtual, val_y leva
@@ -542,7 +542,7 @@ Existem três tipos de uniões externas:
     #| echo: false
     #| out-width: ~
     #| fig-cap: | 
-    #|   Uma representação visual da união completa onde cada linha em `x`
+    #|   Uma representação visual da união completa (*full join*) onde cada linha em `x`
     #|   e `y` aparece na saída.
     #| fig-alt: |
     #|   Agora, x e y têm uma linha virtual que sempre corresponde.
@@ -564,22 +564,22 @@ No entanto, esta não é uma boa representação porque, embora possa refrescar 
 #|   Diagramas de Venn mostrando a diferença entre uniões internas, esquerda, direita e 
 #|   completa.
 #| fig-alt: |
-#|   Diagramas de Venn para uniões internas, completas, esquerda e direita. Cada união
+#|   Diagramas de Venn para uniões internas (*inner join*), completas (*full join*), esquerda (*left join*) e direita (*right join*). Cada união
 #|   representado com dois círculos que se cruzam representando data frame x
 #|   e y, com x à direita e y à esquerda. O sombreamento indica o
 #|   resultado da união. 
 #|
-#|   União interna: a interseção está sombreada. 
-#|   União completa: Tudo está sombreado. 
-#|   União esquerda: Tudo em x está sombreado.
-#|   União direita: Tudo em y está sombreado.
+#|   União interna (*inner join*): a interseção está sombreada. 
+#|   União completa (*full join*): Tudo está sombreado. 
+#|   União esquerda (*left join*): Tudo em x está sombreado.
+#|   União direita (*right join*): Tudo em y está sombreado.
 
 knitr::include_graphics("diagrams/join/venn.png", dpi = 270)
 ```
 
 As uniões mostradas até aqui são chamadas **uniões equivalentes** (*equi joins*), onde as linhas correspondem se as chaves forem iguais.
 Uniões equivalentes (*equi joins*) são o tipo mais comum de união, então normalmente omitiremos o prefixo equi e apenas diremos "união interna" (*inner join*) em vez de "união interna equivalente" (*equi inner join*).
-Voltaremos às unão não-equivalentes (*non-equi joins*) no @sec-non-equi-joins.
+Voltaremos às uniões não-equivalentes (*non-equi joins*) no @sec-non-equi-joins.
 
 ### Correspondências de linhas
 

--- a/joins.qmd
+++ b/joins.qmd
@@ -658,10 +658,10 @@ knitr::include_graphics("diagrams/join/semi.png", dpi = 270)
 #| echo: false
 #| out-width: null
 #| fig-cap: |
-#|   Uma anti-união **anti-join*) é o inverso de uma semi-união (*semi-join*), eliminando linhas de `x`
+#|   Uma anti-união (*anti-join*) é o inverso de uma semi-união (*semi-join*), eliminando linhas de `x`
 #|   que têm uma correspondência em `y`.
 #| fig-alt: |
-#|   Uma anti-união é o inverso de uma semi-união, então as correspondências são desenhadas com
+#|   Uma anti-união (*anti-join*) é o inverso de uma semi-união (*semi-join*), então as correspondências são desenhadas com
 #|   linhas vermelhas indicando que elas serão eliminadas da saída.
 
 knitr::include_graphics("diagrams/join/anti.png", dpi = 270)
@@ -673,7 +673,7 @@ Até agora você só viu uniões equivalentes (*equi joins*), uniões onde as li
 Agora vamos relaxar essa restrição e discutir outras maneiras de determinar se um par de linhas se corresponde.
 
 Mas antes de podermos fazer isso, precisamos rever uma simplificação que fizemos acima.
-Nas uniões equivalentes, as chaves `x` e `y` são sempre iguais, então só precisamos mostrar uma na saída.
+Nas uniões equivalentes (*equi joins*), as chaves `x` e `y` são sempre iguais, então só precisamos mostrar uma na saída.
 Podemos solicitar que dplyr mantenha ambas as chaves com `keep = TRUE`, o que leva ao código abaixo e ao `inner_join()` redesenhado na @ fig-inner-both.
 
 ```{r}

--- a/joins.qmd
+++ b/joins.qmd
@@ -458,7 +458,7 @@ As linhas e colunas na saída são determinadas principalmente por `x`, então a
 #| echo: false
 #| out-width: ~
 #| fig-cap: | 
-#|   TPara entender como funcionam as junções, é útil pensar em todos os possíveis
+#|   Para entender como funcionam as uniões, é útil pensar em todos os possíveis
 #|   correspondências. Aqui mostramos isso com uma grade (grid) de linhas de conexão.
 #| fig-alt: |
 #|   x e y são colocados em ângulos retos, com linhas horizontais estendendo-se 
@@ -718,7 +718,7 @@ União não-equivalente (*non-equi join*) não é um termo particularmente útil
 
 -   **Uniões cruzadas** (*cross joins*) correspondem a cada par de linhas.
 -   **Uniões de desigualdades** (*inequality joins*) usam `<`, `<=`, `>` e `>=` em vez de `==`.
--   **Uniões deslizantes** (*rolling joins*) são semelhantes às junções de desigualdade, mas apenas encontram a correspondência mais próxima.
+-   **Uniões deslizantes** (*rolling joins*) são semelhantes às uniões de desigualdade, mas apenas encontram a correspondência mais próxima.
 -   **Uniões de sobreposições** (*overlap joins*) são um tipo especial de união de desigualdade projetada para trabalhar com intervalos.
 
 Each of these is described in more detail in the following sections.
@@ -762,7 +762,7 @@ Uniões de desigualdade (*inequality joins*) usam `<`, `<=`, `>=` ou `>` para re
 #|   de `x` é menor que a chave de `y`. Isso forma um triângulo
 #|   no canto superior esquerdo.
 #| fig-alt: |
-#|   Um diagrama que descreve uma junção de desigualdade onde um quadro de dados x é unido por 
+#|   Um diagrama que descreve uma união de desigualdade onde um quadro de dados x é unido por 
 #|   um data frame y onde a chave de x é menor que a chave de y, resultando 
 #|   em um triangulo no canto superior esquerdo.
 

--- a/joins.qmd
+++ b/joins.qmd
@@ -286,7 +286,7 @@ Você pode substituir os sufixos padrão pelo argumento `suffix`.
 `join_by(codigo_cauda)` é a abreviação de `join_by(codigo_cauda == codigo_cauda)`.
 É importante conhecer essa forma mais completa por dois motivos.
 Em primeiro lugar, descreve a relação entre as duas tabelas: as chaves devem ser iguais.
-É por isso que esse tipo de junção costuma ser chamado de **união equivalente** (*equi join*).
+É por isso que esse tipo de união costuma ser chamado de **união equivalente** (*equi join*).
 Você aprenderá sobre uniões não equivalentes (*non-equi join*) na @sec-non-equi-joins.
 
 Em segundo lugar, é como você especifica diferentes chaves de união (*join keys*) em cada tabela.
@@ -308,10 +308,10 @@ Em códigos mais antigos, você pode ver uma maneira diferente de especificar as
 Agora que isto existe, preferimos `join_by()` pois fornece uma especificação mais clara e flexível.
 
 `inner_join()`, `right_join()`, `full_join()` têm a mesma interface que `left_join()`.
-A diferença é quais linhas elas mantêm: a *left join* mantém todas as linhas em `x`, a *right join* mantém todas as linhas em `y`, a *full join* mantém todas as linhas em `x` ou `y`, e a *inner join* mantém apenas as linhas que ocorrem em `x` e `y`.
+A diferença é quais linhas as funções mantêm: a *left join* mantém todas as linhas em `x`, a *right join* mantém todas as linhas em `y`, a *full join* mantém todas as linhas em `x` ou `y`, e a *inner join* mantém apenas as linhas que ocorrem em `x` e `y`.
 Voltaremos a isso com mais detalhes posteriormente.
 
-### Uniões de filtragem
+### Uniões de filtragem (*Filtering joins*)
 
 Como você pode imaginar, a ação principal de uma **união de filtragem** (*filtering joins*) é filtrar as linhas.
 Existem dois tipos: semi-união (*semi-join*) e anti-união (*anti-join*).
@@ -341,7 +341,7 @@ flights2 |>
   distinct(dest)
 ```
 
-Or we can find which `tailnum`s are missing from `planes`:
+Ou podemos encontrar cada valor em `codigo_cauda` que estiverem ausentes de `avioes`:
 
 ```{r}
 voos2 |>
@@ -412,10 +412,10 @@ voos2 |>
         coord_quickmap()
     ```
 
-## Como as uniões funcionam?
+## Como as uniões (*joins*) funcionam?
 
 Agora que você já usou uniões (*joins*) algumas vezes, é hora de aprender mais sobre como eles funcionam, focando em como cada linha em `x` corresponde às linhas em `y`.
-Começaremos apresentando uma representação visual de uniões, usando os *tibbles* simples definidos abaixo e mostrados na @fig-join-setup.
+Começaremos apresentando uma representação visual de uniões (*joins*), usando os *tibbles* simples definidos abaixo e mostrados na @fig-join-setup.
 Nestes exemplos usaremos uma única chave chamada `chave` e uma única coluna de valor (`val_x` e `val_y`), mas todas as ideias se generalizam para múltiplas chaves e múltiplos valores.
 
 ```{r}
@@ -719,7 +719,7 @@ União não-equivalente (*non-equi join*) não é um termo particularmente útil
 -   **Uniões cruzadas** (*cross joins*) correspondem a cada par de linhas.
 -   **Uniões de desigualdades** (*inequality joins*) usam `<`, `<=`, `>` e `>=` em vez de `==`.
 -   **Uniões deslizantes** (*rolling joins*) são semelhantes às junções de desigualdade, mas apenas encontram a correspondência mais próxima.
--   **Uniões de sobreposições** (*overlap joins*) são um tipo especial de junção de desigualdade projetada para trabalhar com intervalos.
+-   **Uniões de sobreposições** (*overlap joins*) são um tipo especial de união de desigualdade projetada para trabalhar com intervalos.
 
 Each of these is described in more detail in the following sections.
 
@@ -758,7 +758,7 @@ Uniões de desigualdade (*inequality joins*) usam `<`, `<=`, `>=` ou `>` para re
 #| echo: false
 #| out-width: ~
 #| fig-cap: |
-#|   AUma junção de desigualdade onde `x` é unido a `y` nas linhas onde a chave 
+#|  Uma união de desigualdade onde `x` é unido a `y` nas linhas onde a chave 
 #|   de `x` é menor que a chave de `y`. Isso forma um triângulo
 #|   no canto superior esquerdo.
 #| fig-alt: |

--- a/joins.qmd
+++ b/joins.qmd
@@ -840,7 +840,7 @@ funcionarios |>
 
 Para resolver este problema, precisaremos abordar o problema de uma maneira diferente, com uniões de sobreposições (*overlap joins*).
 
-### Uniões de sobreposições
+### Uniões de sobreposições (*Overlap joins*)
 
 Uniões de sobreposições (*overlap joins*) fornecem três funções de ajuda que usam uniões de desigualdade para facilitar o trabalho com intervalos:
 

--- a/joins.qmd
+++ b/joins.qmd
@@ -1,4 +1,4 @@
-# Uniões {#sec-joins}
+# ✅ Uniões (*joins*) {#sec-joins}
 
 ```{r}
 #| echo: false


### PR DESCRIPTION
Tradução do capitulo joins.qmd.
Notas:

1-) Last observation carried forward : Última observação levada adiante
2-) Zen-like koan: diálogo meio Zen 
3-) Usando codigo_cauda ao invés de cauda. Versao dev de dados está com PR para mudar no nome desta coluna
4-) `Batting`, `People` e `Salaries` do pacote Lahman foram pegos do pacotes dados
5-) Rolling joins ficou "Uniões deslizantes"
Em geral, tentei traduzir os tipos de joins, mas mantive os termos em inglês, pois são mais utilizados pelos cientistas de dados (IMHO).

Sugestões são bem-vindas!